### PR TITLE
check legality of log-space hyperparameters in log space

### DIFF
--- a/ConfigSpace/hyperparameters.py
+++ b/ConfigSpace/hyperparameters.py
@@ -198,6 +198,12 @@ class UniformMixin(object):
     def is_legal(self, value):
         if not super(UniformMixin, self).is_legal(value):
             return False
+        elif self.log:
+            # compute legality in log space due to rounding errors
+            if np.log(self.upper) >= np.log(value) >= np.log(self.lower):
+                return True
+            else:
+                return False
         # Strange numerical issues!
         elif self.upper >= value >= (self.lower - 0.0000000001):
             return True

--- a/ConfigSpace/hyperparameters.py
+++ b/ConfigSpace/hyperparameters.py
@@ -200,7 +200,7 @@ class UniformMixin(object):
             return False
         elif self.log:
             # compute legality in log space due to rounding errors
-            if np.log(self.upper) >= np.log(value) >= np.log(self.lower):
+            if self._upper >= np.log(value) >= self._lower:
                 return True
             else:
                 return False
@@ -249,9 +249,6 @@ class UniformFloatHyperparameter(UniformMixin, FloatHyperparameter):
                              "hyperparameter %s is forbidden." %
                              (self.lower, name))
 
-        super(UniformFloatHyperparameter, self). \
-            __init__(name, self.check_default(default))
-
         if self.log:
             if self.q is not None:
                 lower = self.lower - (np.float64(self.q) / 2. - 0.0001)
@@ -268,6 +265,9 @@ class UniformFloatHyperparameter(UniformMixin, FloatHyperparameter):
             else:
                 self._lower = self.lower
                 self._upper = self.upper
+
+        super(UniformFloatHyperparameter, self). \
+            __init__(name, self.check_default(default))
 
     def __repr__(self):
         repr_str = six.StringIO()

--- a/ConfigSpace/hyperparameters.py
+++ b/ConfigSpace/hyperparameters.py
@@ -435,6 +435,10 @@ class UniformIntegerHyperparameter(UniformMixin, IntegerHyperparameter):
             self.q = None
         self.log = bool(log)
 
+        if self.log:
+            self._lower = np.log(lower)
+            self._upper = np.log(upper)
+
         if self.lower >= self.upper:
             raise ValueError("Upper bound %d must be larger than lower bound "
                              "%d for hyperparameter %s" %

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -555,3 +555,14 @@ class TestHyperparameters(unittest.TestCase):
             return counts_per_bin
 
         self.assertEqual(actual_test(), actual_test())
+
+    def test_log_space_conversion(self):
+        lower, upper = 1e-5, 1e5
+        hyper = UniformFloatHyperparameter('test', lower=lower, upper=upper, 
+            log=True)
+        self.assertTrue(hyper.is_legal(hyper._transform(1.)))
+
+        lower, upper = 1e-10, 1e10
+        hyper = UniformFloatHyperparameter('test', lower=lower, upper=upper, 
+            log=True)
+        self.assertTrue(hyper.is_legal(hyper._transform(1.)))


### PR DESCRIPTION
Hyperparameters defined in log space should check for legality in log space as well. If you have a hyperparameter with large possible values, when its scaled value is on the boundaries of the unit space 0-1 it can be determined to have an illegal value when in fact it was legal.

Ex: 

```
scaled_value = 1.000000001 # a reasonable rounding error simulation
upper, lower = 1e10, 1e-10 # large space, help show issue
log_upper, log_lower = np.log(upper), np.log(lower)
hp_value = np.exp(scaled_value * (log_upper - log_lower) + log_lower)
print(hp_value)
> 10000000460.5
print(hp_value > upper)
> True
```