### PR TITLE
ADD ordinals and unittests for new pcs

### DIFF
--- a/ConfigSpace/io/pcs_new.py
+++ b/ConfigSpace/io/pcs_new.py
@@ -32,7 +32,8 @@ from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
     UniformIntegerHyperparameter, UniformFloatHyperparameter, \
     NumericalHyperparameter, IntegerHyperparameter, FloatHyperparameter, \
-    NormalIntegerHyperparameter, NormalFloatHyperparameter, OrdinalHyperparameter
+    NormalIntegerHyperparameter, NormalFloatHyperparameter, OrdinalHyperparameter,\
+    Constant
 from ConfigSpace.conditions import EqualsCondition, NotEqualsCondition,\
     InCondition, AndConjunction, OrConjunction, ConditionComponent,\
     GreaterThanCondition, LessThanCondition
@@ -85,6 +86,11 @@ def build_ordinal(param):
     return ordinal_template % (param.name, 
                                ", ".join([str(value) for value in param.sequence]),
                                 str(param.default))
+
+def build_constant(param):
+    const_template = '%s categorical {%s} [%s]'
+    return const_template % (param.name,
+                             param.value, param.value)
                                 
 def build_continuous(param):
     if type(param) in (NormalIntegerHyperparameter,
@@ -260,7 +266,8 @@ def read(pcs_string, debug=False):
         create = {"int": UniformIntegerHyperparameter,
                   "float": UniformFloatHyperparameter,
                   "categorical": CategoricalHyperparameter,
-                  "ordinal": OrdinalHyperparameter}
+                  "ordinal": OrdinalHyperparameter
+                  }
 
         try:
             param_list = pp_cont_param.parseString(line)
@@ -415,6 +422,8 @@ def write(configuration_space):
             param_lines.write(build_categorical(hyperparameter))
         elif isinstance(hyperparameter, OrdinalHyperparameter):
             param_lines.write(build_ordinal(hyperparameter))
+        elif isinstance(hyperparameter, Constant):
+            param_lines.write(build_constant(hyperparameter))
         else:
             raise TypeError("Unknown type: %s (%s)" % (
                 type(hyperparameter), hyperparameter))

--- a/test/io/test_pcs_converter.py
+++ b/test/io/test_pcs_converter.py
@@ -339,7 +339,65 @@ class TestPCSConverter(unittest.TestCase):
         cs.add_forbidden_clause(fb)
         value = pcs_new.write(cs)
         self.assertIn(expected, value)
-    
+
+    def test_build_new_GreaterThanFloatCondition(self):
+        expected = "b integer [0, 10] [5]\n" \
+                   "a real [0.0, 1.0] [0.5]\n\n" \
+                   "a | b > 5"
+        cs = ConfigurationSpace()
+        a = UniformFloatHyperparameter("a", 0, 1, 0.5)
+        b = UniformIntegerHyperparameter("b", 0, 10, 5)
+        cs.add_hyperparameter(a)
+        cs.add_hyperparameter(b)
+        cond = GreaterThanCondition(a, b, 5)
+        cs.add_condition(cond)
+
+        value = pcs_new.write(cs)
+        self.assertIn(expected, value)
+
+        expected = "b real [0.0, 10.0] [5.0]\n" \
+                   "a real [0.0, 1.0] [0.5]\n\n" \
+                   "a | b > 5"
+        cs = ConfigurationSpace()
+        a = UniformFloatHyperparameter("a", 0, 1, 0.5)
+        b = UniformFloatHyperparameter("b", 0, 10, 5)
+        cs.add_hyperparameter(a)
+        cs.add_hyperparameter(b)
+        cond = GreaterThanCondition(a, b, 5)
+        cs.add_condition(cond)
+
+        value = pcs_new.write(cs)
+        self.assertIn(expected, value)
+
+    def test_build_new_GreaterThanIntCondition(self):
+        expected = "a real [0.0, 1.0] [0.5]\n" \
+                   "b integer [0, 10] [5]\n\n" \
+                   "b | a > 0.5"
+        cs = ConfigurationSpace()
+        a = UniformFloatHyperparameter("a", 0, 1, 0.5)
+        b = UniformIntegerHyperparameter("b", 0, 10, 5)
+        cs.add_hyperparameter(a)
+        cs.add_hyperparameter(b)
+        cond = GreaterThanCondition(b, a, 0.5)
+        cs.add_condition(cond)
+
+        value = pcs_new.write(cs)
+        self.assertIn(expected, value)
+
+        expected = "a integer [0, 10] [5]\n" \
+                   "b integer [0, 10] [5]\n\n" \
+                   "b | a > 5"
+        cs = ConfigurationSpace()
+        a = UniformIntegerHyperparameter("a", 0, 10, 5)
+        b = UniformIntegerHyperparameter("b", 0, 10, 5)
+        cs.add_hyperparameter(a)
+        cs.add_hyperparameter(b)
+        cond = GreaterThanCondition(b, a, 5)
+        cs.add_condition(cond)
+
+        value = pcs_new.write(cs)
+        self.assertIn(expected, value)
+
     def test_read_new_configuration_space_complex_conditionals(self):
         classi = OrdinalHyperparameter("classi", ["random_forest","extra_trees","k_nearest_neighbors","something"])
         knn_weights = CategoricalHyperparameter("knn_weights", ["uniform", "distance"])
@@ -436,5 +494,5 @@ class TestPCSConverter(unittest.TestCase):
             fh.write(pcs_string)
         with open(name, 'r') as fh:
             pcs_new = pcs.read(fh)
-        assert (pcs_new, cs)
+        self.assertTrue(pcs_new, cs)
 

--- a/test/io/test_pcs_converter.py
+++ b/test/io/test_pcs_converter.py
@@ -328,7 +328,7 @@ class TestPCSConverter(unittest.TestCase):
 
     def test_build_new_forbidden(self):
         expected = "a categorical {a, b, c} [a]\nb categorical {a, b, c} [c]\n\n" \
-                   "{a=a, b=a}\n{a=a, b=b}\n{a=b, b=a}\n{a=b, b=b}"
+                   "{a=a, b=a}\n{a=a, b=b}\n{a=b, b=a}\n{a=b, b=b}\n"
         cs = ConfigurationSpace()
         a = CategoricalHyperparameter("a", ["a", "b", "c"], "a")
         b = CategoricalHyperparameter("b", ["a", "b", "c"], "c")
@@ -338,7 +338,7 @@ class TestPCSConverter(unittest.TestCase):
                                      ForbiddenInClause(b, ["a", "b"]))
         cs.add_forbidden_clause(fb)
         value = pcs_new.write(cs)
-        self.assertIn(expected, value)
+        self.assertEqual(expected, value)
 
     def test_build_new_GreaterThanFloatCondition(self):
         expected = "b integer [0, 10] [5]\n" \
@@ -353,7 +353,7 @@ class TestPCSConverter(unittest.TestCase):
         cs.add_condition(cond)
 
         value = pcs_new.write(cs)
-        self.assertIn(expected, value)
+        self.assertEqual(expected, value)
 
         expected = "b real [0.0, 10.0] [5.0]\n" \
                    "a real [0.0, 1.0] [0.5]\n\n" \
@@ -367,7 +367,7 @@ class TestPCSConverter(unittest.TestCase):
         cs.add_condition(cond)
 
         value = pcs_new.write(cs)
-        self.assertIn(expected, value)
+        self.assertEqual(expected, value)
 
     def test_build_new_GreaterThanIntCondition(self):
         expected = "a real [0.0, 1.0] [0.5]\n" \
@@ -382,7 +382,7 @@ class TestPCSConverter(unittest.TestCase):
         cs.add_condition(cond)
 
         value = pcs_new.write(cs)
-        self.assertIn(expected, value)
+        self.assertEqual(expected, value)
 
         expected = "a integer [0, 10] [5]\n" \
                    "b integer [0, 10] [5]\n\n" \
@@ -396,7 +396,7 @@ class TestPCSConverter(unittest.TestCase):
         cs.add_condition(cond)
 
         value = pcs_new.write(cs)
-        self.assertIn(expected, value)
+        self.assertEqual(expected, value)
 
     def test_read_new_configuration_space_complex_conditionals(self):
         classi = OrdinalHyperparameter("classi", ["random_forest","extra_trees","k_nearest_neighbors","something"])
@@ -494,5 +494,6 @@ class TestPCSConverter(unittest.TestCase):
             fh.write(pcs_string)
         with open(name, 'r') as fh:
             pcs_new = pcs.read(fh)
-        self.assertTrue(pcs_new, cs)
+
+        self.assertEqual(pcs_new, cs)
 


### PR DESCRIPTION
This PR adds the option to write ordinal parameters and adds some more unittests to test the latest pcs format.