### PR TITLE
added: setting sampled value manually

### DIFF
--- a/ConfigSpace/configuration_space.py
+++ b/ConfigSpace/configuration_space.py
@@ -1100,7 +1100,15 @@ class Configuration(object):
             return self[item]
         except:
             return default
-
+            
+    def __setitem__(self, key, value):
+        param = self.configuration_space.get_hyperparameter(key)
+        if param.is_legal(value):
+            self._values[key] = value
+            self._vector[self.configuration_space._hyperparameter_idx[key]] = self.configuration_space.get_hyperparameter(key)._inverse_transform(self[key])
+        else:
+            raise ValueError("Illegal value %s for hyperparameter %s" %(str(value), key))
+        
     def __contains__(self, item: str) -> bool:
         self._populate_values()
         return item in self._values

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -604,6 +604,7 @@ class TestConfigurationSpace(unittest.TestCase):
         self.assertRaisesRegex(TypeError,
                                "Argument size must be of type int, but is "
                                "<class 'float'>", cs.sample_configuration, 1.2)
+                               
 
 
 class ConfigurationTest(unittest.TestCase):
@@ -675,7 +676,47 @@ class ConfigurationTest(unittest.TestCase):
             saved_value = json.loads(string)
             saved_value = byteify(saved_value)
             self.assertEqual(values_dict, saved_value)
-
+            
+    def test_setitem(self):
+        '''
+        Checks overriding a sampled configuration
+        '''
+        pcs = ConfigurationSpace()
+        pcs.add_hyperparameter(UniformIntegerHyperparameter('x0', 1, 5))
+        pcs.add_hyperparameter(UniformFloatHyperparameter('x1', 0.5, 2.55))
+        pcs.add_hyperparameter(CategoricalHyperparameter('x2',['ab', 'bc', 'cd', 'de']))
+        
+        conf = pcs.sample_configuration()
+        
+        # failed because it's a invalid configuration
+        with self.assertRaisesRegex(ValueError, 'Illegal value 0 for hyperparameter x1'):
+            conf['x1'] = 0
+            
+        with self.assertRaisesRegex(ValueError, 'Illegal value 2.5 for hyperparameter x0'):
+            conf['x0'] = 2.5
+        
+        # failed because the variable didn't exists
+        with self.assertRaisesRegex(KeyError, "Hyperparameter 'x_0' does not exist in this configuration space."):
+            conf['x_0'] = 1
+        
+        # successful operation 1
+        x1_old = conf['x1']
+        if x1_old == 1.5:
+            conf['x1'] = 2.1
+        else:
+            conf['x1'] = 1.5
+        x1_new = conf['x1']
+        self.assertNotEqual(x1_old, x1_new)
+        
+        # successful operation 2
+        x2_old = conf['x2']
+        if x2_old == 'ab':
+            conf['x2'] = 'cd'
+        else:
+            conf['x2'] = 'ab'
+        x2_new = conf['x2']
+        self.assertNotEqual(x2_old, x2_new)
+        
 
 
 


### PR DESCRIPTION
added the possibility to overwrite a specific value of a parameter manually after sampling the configuration.

e.g:
conf = pcs.sample_configuration()
conf['param_name'] = 0

[ as requested by @sfalkner ]