### PR TITLE
FIX #56; Write Conjunctions in new pcs format

### DIFF
--- a/ConfigSpace/io/pcs_new.py
+++ b/ConfigSpace/io/pcs_new.py
@@ -452,13 +452,12 @@ def write(configuration_space):
                 type(hyperparameter), hyperparameter))
 
     for condition in configuration_space.get_conditions():
-        if isinstance(condition, AndConjunction) or isinstance(condition, OrConjunction):
-            condition_lines.write(build_conjunction(condition) + "\n")
-        else:
-            if condition_lines.tell() > 0:
+        if condition_lines.tell() > 0:
                 condition_lines.write("\n")
+        if isinstance(condition, AndConjunction) or isinstance(condition, OrConjunction):
+            condition_lines.write(build_conjunction(condition))
+        else:
             condition_lines.write(build_condition(condition))
-
 
     for forbidden_clause in configuration_space.forbidden_clauses:
         # Convert in-statement into two or more equals statements

--- a/test/io/test_pcs_converter.py
+++ b/test/io/test_pcs_converter.py
@@ -473,6 +473,22 @@ class TestPCSConverter(unittest.TestCase):
 
         pcs_new.read(s.split('\n'))
 
+    def test_write_restrictions(self):
+        s = "c integer [0, 2] [0]\n" + \
+            "d ordinal {cold, luke-warm, hot} [cold]\n" + \
+            "e real [0.0, 1.0] [0.0]\n" + \
+            "b real [0.0, 1.0] [0.0]\n" + \
+            "a real [0.0, 1.0] [0.0]\n" + \
+            "\n" + \
+            "b | d in {luke-warm, hot} || c > 1\n" + \
+            "a | b == 0.5 && e > 0.5\n"
+
+        a = pcs_new.read(s.split('\n'))
+        out = pcs_new.write(a)
+        print(s)
+        print(out)
+        self.assertEqual(out, s)
+
     def test_read_write(self):
         # Some smoke tests whether reading, writing, reading alters makes the
         #  configspace incomparable

--- a/test/io/test_pcs_converter.py
+++ b/test/io/test_pcs_converter.py
@@ -481,12 +481,10 @@ class TestPCSConverter(unittest.TestCase):
             "a real [0.0, 1.0] [0.0]\n" + \
             "\n" + \
             "b | d in {luke-warm, hot} || c > 1\n" + \
-            "a | b == 0.5 && e > 0.5\n"
+            "a | b == 0.5 && e > 0.5"
 
         a = pcs_new.read(s.split('\n'))
         out = pcs_new.write(a)
-        print(s)
-        print(out)
         self.assertEqual(out, s)
 
     def test_read_write(self):


### PR DESCRIPTION
Modified pcs_new writer to deal with Conjunctions. Not sure whether there is a better solution for L166 where I manually split a condition in order to get all variables (plus conditions) the child depends on.


