### PR TITLE
Remove argparse from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
     author_email='feurerm@informatik.uni-freiburg.de',
     test_suite="nose.collector",
     install_requires=[
-        'argparse',
         'numpy',
         'pyparsing',
         'typing',


### PR DESCRIPTION
argparse is a system library in Python2.7+ and Python3.2+
So if you don't support earlier versions, you don't need it. More than that dependency can pull out old version of argparse from PyPI and install it hiding system module