### PR TITLE
Cleanup setup.py. If numpy is not installed, attempt to install it with pip.

### DIFF
--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -29,9 +29,9 @@ conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
 
 if [[ ! -z "$NPY_VERSION" ]]; then
-    conda install -y numpy=$NPY_VERSION pytest pytest-cov cython
+    conda install -y pytest pytest-cov cython
 else
-    conda install -y numpy pytest pytest-cov cython
+    conda install -y pytest pytest-cov cython
 fi
 pip install codecov typing
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ AUTHORS = ', '.join(["Matthias Feurer", "Katharina Eggensperger",
                      "Marius Lindauer", "Jorn Tuyls"]),
 AUTHOR_EMAIL = 'feurerm@informatik.uni-freiburg.de'
 TEST_SUITE = "pytest"
-SETUP_REQS = ['Cython']
+SETUP_REQS = ['Cython', 'numpy']
 INSTALL_REQS = ['numpy', 'pyparsing', 'typing', 'Cython']
 MIN_PYTHON_VERSION = '>=3.4.*'
 CLASSIFIERS = ['Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -1,98 +1,100 @@
+"""Setup.py for ConfigSpace"""
+
+import os
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
-import os
 import numpy as np
 
 # Read http://peterdowns.com/posts/first-time-with-pypi.html to figure out how
 # to publish the package on PyPI
 
-here = os.path.abspath(os.path.dirname(__file__))
-desc = 'Creation and manipulation of parameter configuration spaces for ' \
+# Helper functions
+def read_file(fname):
+    """Get contents of file from the modules directory"""
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def get_version(fname):
+    """Get the module version"""
+    with open(fname) as file_handle:
+        return file_handle.readlines()[-1].split()[-1].strip("\"'")
+
+# Configure setup parameters
+MODULE_NAME = 'ConfigSpace'
+MODULE_URL = 'https://github.com/automl/ConfigSpace'
+SHORT_DESCRIPTION = 'Creation and manipulation of parameter configuration spaces for ' \
        'automated algorithm configuration and hyperparameter tuning.'
-keywords = 'algorithm configuration hyperparameter optimization empirical ' \
+KEYWORDS = 'algorithm configuration hyperparameter optimization empirical ' \
            'evaluation black box'
+LICENSE = 'BSD 3-clause'
+PLATS = ['Linux']
+AUTHORS = ', '.join(["Matthias Feurer", "Katharina Eggensperger",
+                     "Syed Mohsin Ali", "Christina Hernandez Wunsch",
+                     "Julien-Charles Levesque", "Jost Tobias Springenberg", "Philipp Mueller"
+                     "Marius Lindauer", "Jorn Tuyls"]),
+AUTHOR_EMAIL = 'feurerm@informatik.uni-freiburg.de'
+TEST_SUITE = "pytest"
+SETUP_REQS = ['Cython']
+INSTALL_REQS = ['numpy', 'pyparsing', 'typing', 'Cython']
+MIN_PYTHON_VERSION = '>=3.4.*'
+CLASSIFIERS = ['Programming Language :: Python :: 3.4',
+               'Programming Language :: Python :: 3.5',
+               'Programming Language :: Python :: 3.6',
+               'Programming Language :: Python :: 3.7',
+               'Development Status :: 4 - Beta',
+               'Natural Language :: English',
+               'Intended Audience :: Developers',
+               'Intended Audience :: Education',
+               'Intended Audience :: Science/Research',
+               'License :: OSI Approved :: BSD License',
+               'Operating System :: POSIX :: Linux',
+               'Topic :: Scientific/Engineering :: Artificial Intelligence',
+               'Topic :: Scientific/Engineering',
+               'Topic :: Software Development']
 
 # These do not really change the speed of the benchmarks
-compiler_directives = {
+COMPILER_DIRECTIVES = {
     'boundscheck': False,
     'wraparound': False,
 }
 
-extensions = [
-    Extension('ConfigSpace.hyperparameters',
-              sources=['ConfigSpace/hyperparameters.pyx'],
-              include_dirs=[np.get_include()]),
-    Extension('ConfigSpace.forbidden',
-              sources=['ConfigSpace/forbidden.pyx'],
-              include_dirs=[np.get_include()]),
-    Extension('ConfigSpace.conditions',
-              sources=['ConfigSpace/conditions.pyx'],
-              include_dirs=[np.get_include()]),
-    Extension('ConfigSpace.c_util',
-              sources=['ConfigSpace/c_util.pyx'],
-              include_dirs=[np.get_include()]),
-    Extension('ConfigSpace.util',
-              sources=['ConfigSpace/util.pyx'],
-              include_dirs=[np.get_include()]),
-    Extension('ConfigSpace.configuration_space',
-              sources=['ConfigSpace/configuration_space.pyx'],
-              include_dirs=[np.get_include()])
-]
+EXTENSIONS = [Extension('ConfigSpace.hyperparameters',
+                        sources=['ConfigSpace/hyperparameters.pyx'],
+                        include_dirs=[np.get_include()]),
+              Extension('ConfigSpace.forbidden',
+                        sources=['ConfigSpace/forbidden.pyx'],
+                        include_dirs=[np.get_include()]),
+              Extension('ConfigSpace.conditions',
+                        sources=['ConfigSpace/conditions.pyx'],
+                        include_dirs=[np.get_include()]),
+              Extension('ConfigSpace.c_util',
+                        sources=['ConfigSpace/c_util.pyx'],
+                        include_dirs=[np.get_include()]),
+              Extension('ConfigSpace.util',
+                        sources=['ConfigSpace/util.pyx'],
+                        include_dirs=[np.get_include()]),
+              Extension('ConfigSpace.configuration_space',
+                        sources=['ConfigSpace/configuration_space.pyx'],
+                        include_dirs=[np.get_include()])]
 
-for e in extensions:
-    e.cython_directives = compiler_directives
-
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-
-with open("ConfigSpace/__version__.py") as fh:
-    version = fh.readlines()[-1].split()[-1].strip("\"'")
+for e in EXTENSIONS:
+    e.cython_directives = COMPILER_DIRECTIVES
 
 
 setup(
-    name='ConfigSpace',
-    version=version,
-    url='https://github.com/automl/ConfigSpace',
-    description=desc,
-    ext_modules=extensions,
-    long_description=read("README.md"),
-    license='BSD 3-clause',
-    platforms=['Linux'],
-    author=', '.join(["Matthias Feurer", "Katharina Eggensperger",
-                      "Syed Mohsin Ali", "Christina Hernandez Wunsch",
-                      "Julien-Charles Levesque", "Jost Tobias Springenberg", "Philipp Mueller"
-                      "Marius Lindauer", "Jorn Tuyls"]),
-    author_email='feurerm@informatik.uni-freiburg.de',
-    test_suite="pytest",
-    # https://stackoverflow.com/questions/24923003/organizing-a-package-with-cython
-    setup_requires=[
-        'Cython',
-    ],
-    install_requires=[
-        'numpy',
-        'pyparsing',
-        'typing',
-        'Cython',
-    ],
-    keywords=keywords,
+    name=MODULE_NAME,
+    version=get_version('ConfigSpace/__version__.py'),
+    url=MODULE_URL,
+    description=SHORT_DESCRIPTION,
+    ext_modules=EXTENSIONS,
+    long_description=read_file("README.md"),
+    license=LICENSE,
+    platforms=PLATS,
+    author=AUTHORS,
+    author_email=AUTHOR_EMAIL,
+    test_suite=TEST_SUITE,
+    setup_requires=SETUP_REQS,
+    install_requires=INSTALL_REQS,
+    keywords=KEYWORDS,
     packages=find_packages(),
-    python_requires='>=3.4.*',
-    classifiers=[
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Development Status :: 4 - Beta',
-        'Natural Language :: English',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: POSIX :: Linux',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development',
-    ]
+    python_requires=MIN_PYTHON_VERSION,
+    classifiers=CLASSIFIERS
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,14 @@
 import os
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
-import numpy as np
+
+try:
+    import numpy as np
+except ImportError:
+    print("Numpy module not found. Attempting to install for user using pip..")
+    from pip import main as pip
+    pip(['install', '--user', 'numpy'])
+    import numpy as np
 
 # Read http://peterdowns.com/posts/first-time-with-pypi.html to figure out how
 # to publish the package on PyPI


### PR DESCRIPTION
Adding numpy to install_requires and setup_requires alone doesn't suffice as setup.py itself uses numpy (to get the headers using np.get_include()). So attempt to install it using pip if there is an error in importing numpy. Conservatively install numpy specific to the user (using --user) to avoid overwriting global/needing permissions to install for all users.