### PR TITLE
Fix error message regarding swapped upper/lower bounds in hyperparameters.pyx

### DIFF
--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -407,7 +407,7 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
         if self.lower >= self.upper:
             raise ValueError("Upper bound %f must be larger than lower bound "
                              "%f for hyperparameter %s" %
-                             (self.lower, self.upper, name))
+                             (self.upper, self.lower, name))
         elif log and self.lower <= 0:
             raise ValueError("Negative lower bound (%f) for log-scale "
                              "hyperparameter %s is forbidden." %


### PR DESCRIPTION
Fixed an error message in `hyperparameters.pyx` where upper and lower bound in string formatting was swapped.