### PR TITLE
Fix quantization in UniformIntegerHyperparameter sampling

### DIFF
--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -796,8 +796,12 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
         # Map all floats which belong to the same integer value to the same
         # float value by first transforming it to an integer and then
         # transforming it back to a float between zero and one
-        value = self._transform(value)
-        value = self._inverse_transform(value)
+        if isinstance(value, np.ndarray):
+            value = np.vectorize(self._transform)(value)
+            value = np.vectorize(self._inverse_transform)(value)
+        else:
+            value = self._transform(value)
+            value = self._inverse_transform(value)
         return value
 
     def _transform(self, vector: Union[np.ndarray, float, int]) -> Optional[Union[np.ndarray, float, int]]:

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -855,3 +855,12 @@ class ConfigurationTest(unittest.TestCase):
         for i in range(10):
             config = cs.sample_configuration()
             {hp_name: config[hp_name] for hp_name in config if config[hp_name] is not None}
+
+    def test_multi_sample_quantized_uihp(self):
+        # This unit test covers a problem with sampling multiple entries at a time from a configuration space with at
+        # least one UniformIntegerHyperparameter which is quantized.
+        cs = ConfigurationSpace()
+        cs.add_hyperparameter(UniformIntegerHyperparameter("uihp", lower=1, upper=100, q=2, log=False))
+
+        self.assertIsNotNone(cs.sample_configuration(size=1))
+        self.assertEqual(10, len(cs.sample_configuration(size=10)))

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -660,6 +660,34 @@ class TestHyperparameters(unittest.TestCase):
             values.append(hp._sample(rs))
         self.assertEqual(len(np.unique(values)), 11)
 
+    def test_quantization_UniformIntegerHyperparameter(self):
+        hp = UniformIntegerHyperparameter("uihp", 1, 100, q=3)
+        rs = np.random.RandomState(1)
+
+        sample_one = hp._sample(rs=rs, size=1)
+        self.assertIsInstance(obj=sample_one, cls=np.ndarray)
+        self.assertEqual(1, sample_one.size)
+        self.assertTrue(hp._transform(sample_one) % 3 == 0)
+
+        sample_hundred = hp._sample(rs=rs, size=100)
+        self.assertIsInstance(obj=sample_hundred, cls=np.ndarray)
+        self.assertEqual(100, sample_hundred.size)
+        self.assertTrue(np.all(hp._transform(val) % 3 == 0 for val in sample_hundred))
+
+    def test_quantization_UniformFloatHyperparameter(self):
+        hp = UniformFloatHyperparameter("ufhp", 1, 100, q=3)
+        rs = np.random.RandomState(1)
+
+        sample_one = hp._sample(rs=rs, size=1)
+        self.assertIsInstance(obj=sample_one, cls=np.ndarray)
+        self.assertEqual(1, sample_one.size)
+        self.assertTrue(hp._transform(sample_one) % 3 == 0)
+
+        sample_hundred = hp._sample(rs=rs, size=100)
+        self.assertIsInstance(obj=sample_hundred, cls=np.ndarray)
+        self.assertEqual(100, sample_hundred.size)
+        self.assertTrue(np.all(hp._transform(val) % 3 == 0 for val in sample_hundred))
+
     def test_sample_NormalIntegerHyperparameter(self):
         def sample(hp):
             lower = -30


### PR DESCRIPTION
This pull request tries to fix an issue when sampling more than one configuration at a time (size>1), see issue #119. 