### PR TITLE
More performance improvements for generating neighbors

### DIFF
--- a/ConfigSpace/hyperparameters.pxd
+++ b/ConfigSpace/hyperparameters.pxd
@@ -1,4 +1,5 @@
 # cython: language_level=3
+from typing import Union
 
 import numpy as np
 cimport numpy as np
@@ -21,3 +22,26 @@ cdef class Hyperparameter(object):
 
     cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2)
     cpdef bint is_legal_vector(self, DTYPE_t value)
+    # cpdef float _transform_scalar(self, float scalar)
+    cpdef np.ndarray _transform_vector(self, np.ndarray scalar)
+
+cdef class NumericalHyperparameter(Hyperparameter):
+    cdef public lower
+    cdef public upper
+    cdef public q
+    cdef public log
+    cdef public _lower
+    cdef public _upper
+    cpdef int compare(self, value: Union[int, float, str], value2: Union[int, float, str])
+    cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2)
+    cpdef np.ndarray _apply_quantization_factor_on_vector(self, np.ndarray vector)
+
+
+cdef class IntegerHyperparameter(NumericalHyperparameter):
+    cpdef int _transform_scalar(self, float scalar)
+    cpdef float _apply_quantization_factor_on_scalar(self, float scalar)
+    cdef ufhp
+
+cdef class FloatHyperparameter(NumericalHyperparameter):
+    cpdef float _transform_scalar(self, float scalar)
+    cpdef float _apply_quantization_factor_on_scalar(self, float scalar)

--- a/ConfigSpace/hyperparameters.pxd
+++ b/ConfigSpace/hyperparameters.pxd
@@ -1,6 +1,5 @@
 # cython: language_level=3
 from typing import Union
-
 import numpy as np
 cimport numpy as np
 
@@ -13,7 +12,6 @@ DTYPE = np.float
 # type with a _t-suffix.
 ctypedef np.float_t DTYPE_t
 
-
 cdef class Hyperparameter(object):
     cdef public str name
     cdef public default_value
@@ -22,8 +20,6 @@ cdef class Hyperparameter(object):
 
     cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2)
     cpdef bint is_legal_vector(self, DTYPE_t value)
-    # cpdef float _transform_scalar(self, float scalar)
-    cpdef np.ndarray _transform_vector(self, np.ndarray scalar)
 
 cdef class NumericalHyperparameter(Hyperparameter):
     cdef public lower
@@ -34,14 +30,12 @@ cdef class NumericalHyperparameter(Hyperparameter):
     cdef public _upper
     cpdef int compare(self, value: Union[int, float, str], value2: Union[int, float, str])
     cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2)
-    cpdef np.ndarray _apply_quantization_factor_on_vector(self, np.ndarray vector)
-
 
 cdef class IntegerHyperparameter(NumericalHyperparameter):
-    cpdef int _transform_scalar(self, float scalar)
-    cpdef float _apply_quantization_factor_on_scalar(self, float scalar)
     cdef ufhp
+    cpdef int _transform_scalar(self, double scalar)
+    cpdef np.ndarray _transform_vector(self, np.ndarray vector)
 
 cdef class FloatHyperparameter(NumericalHyperparameter):
-    cpdef float _transform_scalar(self, float scalar)
-    cpdef float _apply_quantization_factor_on_scalar(self, float scalar)
+    cpdef double _transform_scalar(self, double scalar)
+    cpdef np.ndarray _transform_vector(self, np.ndarray vector)

--- a/ConfigSpace/hyperparameters.pxd
+++ b/ConfigSpace/hyperparameters.pxd
@@ -33,7 +33,7 @@ cdef class NumericalHyperparameter(Hyperparameter):
 
 cdef class IntegerHyperparameter(NumericalHyperparameter):
     cdef ufhp
-    cpdef int _transform_scalar(self, double scalar)
+    cpdef long _transform_scalar(self, double scalar)
     cpdef np.ndarray _transform_vector(self, np.ndarray vector)
 
 cdef class FloatHyperparameter(NumericalHyperparameter):

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -377,7 +377,7 @@ cdef class IntegerHyperparameter(NumericalHyperparameter):
             return None
         return self._transform_scalar(vector)
 
-    cpdef int _transform_scalar(self, double scalar):
+    cpdef long _transform_scalar(self, double scalar):
         raise NotImplementedError()
 
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
@@ -854,7 +854,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
 
         return np.rint(vector)
 
-    cpdef int _transform_scalar(self, double scalar):
+    cpdef long _transform_scalar(self, double scalar):
         if not math.isfinite(scalar):
             raise ValueError()
         scalar = self.ufhp._transform_scalar(scalar)
@@ -1167,7 +1167,7 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
         vector = self.nfhp._transform_vector(vector)
         return np.rint(vector)
 
-    cpdef int _transform_scalar(self, double scalar):
+    cpdef long _transform_scalar(self, double scalar):
         if not math.isfinite(scalar):
             raise ValueError()
         scalar = self.nfhp._transform_scalar(scalar)
@@ -1605,7 +1605,7 @@ cdef class OrdinalHyperparameter(Hyperparameter):
                              'hyperparameter %s with an integer, but provided '
                              'the following float: %f' % (self, vector))
 
-    cpdef int _transform_scalar(self, double scalar):
+    cpdef long _transform_scalar(self, double scalar):
         if not math.isfinite(scalar):
             raise ValueError('number %s contains non-finite numbers' % scalar)
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -508,7 +508,7 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
 
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         if np.isnan(vector).any():
-            raise ValueError()
+            raise ValueError('Vector %s contains NaN\'s' % vector)
         vector = vector * (self._upper - self._lower) + self._lower
         if self.log:
             vector = np.exp(vector)
@@ -517,8 +517,8 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
         return np.maximum(self.lower, np.minimum(self.upper, vector))
 
     cpdef double _transform_scalar(self, double scalar):
-        if scalar == np.nan:
-            raise ValueError()
+        if scalar != scalar:
+            raise ValueError('Number %s is NaN' % scalar)
         scalar = scalar * (self._upper - self._lower) + self._lower
         if self.log:
             scalar = math.exp(scalar)
@@ -713,7 +713,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
 
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         if np.isnan(vector).any():
-            raise ValueError()
+            raise ValueError('Vector %s contains NaN\'s' % vector)
         if self.log:
             vector = np.exp(vector)
         if self.q is not None:
@@ -721,8 +721,8 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         return vector
 
     cpdef double _transform_scalar(self, double scalar):
-        if scalar == np.nan:
-            raise ValueError()
+        if scalar != scalar:
+            raise ValueError('Number %s is NaN' % scalar)
         if self.log:
             scalar = math.exp(scalar)
         if self.q is not None:
@@ -1347,7 +1347,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
 
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         if np.isnan(vector).any():
-            raise ValueError('vector %s contains non-finite numbers' % vector)
+            raise ValueError('Vector %s contains NaN\'s' % vector)
 
         if np.equal(np.mod(vector, 1), 0):
             return self.choices[vector.astype(int)]
@@ -1357,8 +1357,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
                              'the following float: %f' % (self, vector))
 
     def _transform_scalar(self, scalar: Union[float, int]) -> Union[float, int, str]:
-        if scalar == np.nan:
-            raise ValueError('number %s contains non-finite numbers' % scalar)
+        if scalar != scalar:
+            raise ValueError('Number %s is NaN' % scalar)
 
         if scalar % 1 == 0:
             return self.choices[int(scalar)]
@@ -1587,7 +1587,7 @@ cdef class OrdinalHyperparameter(Hyperparameter):
 
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         if np.isnan(vector).any():
-            raise ValueError('vector %s contains non-finite numbers' % vector)
+            raise ValueError('Vector %s contains NaN\'s' % vector)
 
         if np.equal(np.mod(vector, 1), 0):
             return self.sequence[vector.astype(int)]
@@ -1597,8 +1597,8 @@ cdef class OrdinalHyperparameter(Hyperparameter):
                              'the following float: %f' % (self, vector))
 
     def _transform_scalar(self, scalar: Union[float, int]) -> Union[float, int, str]:
-        if scalar == np.nan:
-            raise ValueError('number %s contains non-finite numbers' % scalar)
+        if scalar != scalar:
+            raise ValueError('Number %s is NaN' % scalar)
 
         if scalar % 1 == 0:
             return self.sequence[int(scalar)]

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -34,8 +34,8 @@ import warnings
 from collections import OrderedDict, Counter
 from typing import List, Any, Dict, Union, Set, Tuple, Optional
 
-cimport numpy as np
 import numpy as np
+cimport numpy as np
 
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
@@ -332,13 +332,12 @@ cdef class FloatHyperparameter(NumericalHyperparameter):
         raise NotImplementedError()
 
     def _transform(self, vector: Union[np.ndarray, float, int]) -> Optional[Union[np.ndarray, float, int]]:
-        if isinstance(vector, np.ndarray):
-            if np.any(np.isnan(vector)):
-                return None
-            return self._transform_vector(vector)
-        elif np.isnan(vector):
+        try:
+            if isinstance(vector, np.ndarray):
+                return self._transform_vector(vector)
+            return self._transform_scalar(vector)
+        except ValueError:
             return None
-        return self._transform_scalar(vector)
 
     cpdef double _transform_scalar(self, double scalar):
         raise NotImplementedError()
@@ -369,13 +368,12 @@ cdef class IntegerHyperparameter(NumericalHyperparameter):
         return int(parameter)
 
     def _transform(self, vector: Union[np.ndarray, float, int]) -> Optional[Union[np.ndarray, float, int]]:
-        if isinstance(vector, np.ndarray):
-            if np.any(np.isnan(vector)):
-                return None
-            return self._transform_vector(vector)
-        elif np.isnan(vector):
+        try:
+            if isinstance(vector, np.ndarray):
+                return self._transform_vector(vector)
+            return self._transform_scalar(vector)
+        except ValueError:
             return None
-        return self._transform_scalar(vector)
 
     cpdef long _transform_scalar(self, double scalar):
         raise NotImplementedError()
@@ -1380,9 +1378,12 @@ cdef class CategoricalHyperparameter(Hyperparameter):
                              'the following float: %f' % (self, scalar))
 
     def _transform(self, vector: Union[np.ndarray, float, int, str]) -> Optional[Union[np.ndarray, float, int]]:
-        if isinstance(vector, np.ndarray):
-            return self._transform_vector(vector)
-        return self._transform_scalar(vector)
+        try:
+            if isinstance(vector, np.ndarray):
+                return self._transform_vector(vector)
+            return self._transform_scalar(vector)
+        except ValueError:
+            return None
 
     def _inverse_transform(self, vector: Union[None, str, float, int]) -> Union[int, float]:
         if vector is None:
@@ -1617,9 +1618,12 @@ cdef class OrdinalHyperparameter(Hyperparameter):
                              'the following float: %f' % (self, scalar))
 
     def _transform(self, vector: Union[np.ndarray, float, int]) -> Optional[Union[np.ndarray, float, int]]:
-        if isinstance(vector, np.ndarray):
-            return self._transform_vector(vector)
-        return self._transform_scalar(vector)
+        try:
+            if isinstance(vector, np.ndarray):
+                return self._transform_vector(vector)
+            return self._transform_scalar(vector)
+        except ValueError:
+            return None
 
     def _inverse_transform(self, vector: Optional[Union[np.ndarray, List, int, str, float]]) -> Union[float, List[int], List[str], List[float]]:
         if vector is None:

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1605,7 +1605,7 @@ cdef class OrdinalHyperparameter(Hyperparameter):
                              'hyperparameter %s with an integer, but provided '
                              'the following float: %f' % (self, vector))
 
-    cpdef long _transform_scalar(self, double scalar):
+    def _transform_scalar(self, scalar: Union[float, int]) -> Union[float, int, str]:
         if not math.isfinite(scalar):
             raise ValueError('number %s contains non-finite numbers' % scalar)
 


### PR DESCRIPTION
I have added more performance improvements and cleaned up the code for the `_transform()` functions so that it is more consistent and has less code repetition.

I ran the unit tests locally on my computer and found that running all cases took **~36 seconds** with the code in my previous pull request (#127). This is now further reduced to **~16 seconds**.