### PR TITLE
Fixes #137 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ from setuptools.command.build_ext import build_ext
 # Helper functions
 def read_file(fname):
     """Get contents of file from the modules directory"""
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 
 def get_version(fname):
     """Get the module version"""
-    with open(fname) as file_handle:
+    with open(fname, encoding='utf-8') as file_handle:
         return file_handle.readlines()[-1].split()[-1].strip("\"'")
 
 


### PR DESCRIPTION
This should fix the UnicodeDecodeError #137.

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1060: ordinal not in range(128)
```bash
>>> open('README.md').read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1060: ordinal not in range(128)`
```

```bash
>>> open('README.md', encoding='utf-8').read()
'# ConfigSpace\n\nA simple python module to  ...
```