### PR TITLE
Fixed "probabilities" can't copy bug in "add_configuration_space"

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -634,7 +634,8 @@ class ConfigurationSpace(object):
 
         new_parameters = []
         for hp in configuration_space.get_hyperparameters():
-            new_parameter = copy.copy(hp)
+            new_parameter = copy.deepcopy(hp)
+            # fixme: is use copy , "probabilities" will not be copy. to fix it , use deepcopy instead
             # Allow for an empty top-level parameter
             if new_parameter.name == '':
                 new_parameter.name = prefix

--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -635,7 +635,7 @@ class ConfigurationSpace(object):
         new_parameters = []
         for hp in configuration_space.get_hyperparameters():
             new_parameter = copy.deepcopy(hp)
-            # fixme: is use copy , "probabilities" will not be copy. to fix it , use deepcopy instead
+            # fixme: if use copy , "probabilities" will not be copy. to fix it , use deepcopy instead
             # Allow for an empty top-level parameter
             if new_parameter.name == '':
                 new_parameter.name = prefix

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -64,6 +64,23 @@ class TestConfigurationSpace(unittest.TestCase):
     # and over again throughout this test suite
     # TODO make sure that every function here tests one aspect of the
     # configuration space object!
+    def test_add_configuration_space_probabilities(self):
+        from copy import copy,deepcopy
+        from pickle import dumps,loads
+        weights=[0.25,0.5,0.25]
+        hp = CategoricalHyperparameter("B", ["1", "2", "3"], weights=weights)
+        sub_cs = ConfigurationSpace()
+        sub_cs.add_hyperparameter(hp)
+        cs = ConfigurationSpace()
+        cs.add_configuration_space("A", sub_cs)
+        self.assertEqual(deepcopy(sub_cs).get_hyperparameter("B").probabilities, weights)
+        self.assertEqual(copy(sub_cs).get_hyperparameter("B").probabilities, weights)
+        self.assertEqual(loads(dumps(sub_cs)).get_hyperparameter("B").probabilities, weights)
+        self.assertEqual(cs.get_hyperparameter("A:B").probabilities, weights)
+        self.assertEqual(deepcopy(cs).get_hyperparameter("A:B").probabilities, weights)
+        self.assertEqual(copy(cs).get_hyperparameter("A:B").probabilities, weights)
+        self.assertEqual(loads(dumps(cs)).get_hyperparameter("A:B").probabilities, weights)
+
     def test_add_hyperparameter(self):
         cs = ConfigurationSpace()
         hp = UniformIntegerHyperparameter("name", 0, 10)


### PR DESCRIPTION
in configuration_space.pyx#add_configuration_space, if add child configuration_space to parent, the "probabilities" attribute will disappear, in another way, "probabilities" can't copy bug in "add_configuration_space" function. To fix it , I use "copy.deepcopy" instead of "copy.copy" in ConfigSpace/configuration_space.pyx:637 .