### PR TITLE
Add Callable support for CategoricalHyperparameter

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -52,7 +52,7 @@ from ConfigSpace.forbidden import (
     AbstractForbiddenClause,
     AbstractForbiddenConjunction,
 )
-from typing import Union, List, Any, Dict, Iterable, Set, Tuple, Optional
+from typing import Union, List, Any, Dict, Iterable, Set, Tuple, Optional, Callable
 from ConfigSpace.exceptions import ForbiddenValueError
 import ConfigSpace.c_util
 
@@ -1310,7 +1310,7 @@ class ConfigurationSpace(object):
 
 class Configuration(object):
     def __init__(self, configuration_space: ConfigurationSpace,
-                 values: Union[None,  Dict[str, Union[str, float, int]]] = None,
+                 values: Union[None,  Dict[str, Union[str, float, int, Callable[[], Any]]]] = None,
                  vector: Union[None, np.ndarray] = None,
                  allow_inactive_with_values: bool = False, origin: Any = None) -> None:
         """

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -519,6 +519,23 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(f1, f1_)
         self.assertEqual("param, Type: Categorical, Choices: {a, b}, Default: a", str(f1))
 
+    def test_categorical_callable(self):
+        def fn_1(): return 1
+        def fn_2(): return 2
+        f1 = CategoricalHyperparameter("param", [fn_1, fn_2])
+        f1_ = CategoricalHyperparameter("param", [fn_1, fn_2])
+        self.assertEqual(f1, f1_)
+        self.assertEqual("param, Type: Categorical, Choices: {{{}, {}}}, Default: {}".format(fn_1, fn_2, fn_1), str(f1))
+
+        f2 = CategoricalHyperparameter("param", [fn_2, fn_1])
+        self.assertNotEqual(f1, f2)
+
+        def fn_3(): return 3
+        self.assertTrue(f1.is_legal(fn_1))
+        self.assertTrue(f1.is_legal(fn_2))
+        self.assertFalse(f1.is_legal(fn_3))
+        self.assertFalse(f1.is_legal(fn_1()))
+
     def test_categorical_is_legal(self):
         f1 = CategoricalHyperparameter("param", ["a", "b"])
         self.assertTrue(f1.is_legal("a"))


### PR DESCRIPTION
fix #133 

One can now directly pass a Callable when creating a `CategoricalHyperparameter`. This is streamlining prototyping. Couple of examples:

- `CategoricalHyperparameter('final_activation', [nn.Softmax(dim=1), nn.Sigmoid()])`
- `CategoricalHyperparameter('loss_function', [nn.L1Loss, nn.MSELoss])`

Previously, one needed to provide strings, check value later and create the object accordingly.

I've checked my changes on a heavy hyperparameter optimization project of mine and works like a charm. Let me know if any comment!