### PR TITLE
Adding pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.md
 recursive-include ConfigSpace *.pyx *.pxd
 include LICENSE
+include pyproject.toml

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Version 0.5.15
+
+* Add `pyproject.toml` to support wheel installation as required in 
+  [PEP518](https://medium.com/@grassfedcode/pep-517-and-518-in-plain-english-47208ca8b7a6)
+
 # Version 0.4.14
 
 * ADD new argument `config_id` to `Configuration` which can be set by an application

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -28,7 +28,7 @@ popd
 conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
 
-pip install codecov pytest pytest-cov cython
+pip install codecov pytest pytest-cov
 
 if [[ "$INSTALL_FROM_SDIST" == "true" ]]; then
     pip install twine
@@ -39,6 +39,7 @@ if [[ "$INSTALL_FROM_SDIST" == "true" ]]; then
     twine check $dist
     pip install "$dist"
 else
+    pip install cython
     python setup.py install
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]


### PR DESCRIPTION
Add `pyproject.toml` to support wheel installation as required in [PEP518](https://medium.com/@grassfedcode/pep-517-and-518-in-plain-english-47208ca8b7a6)