### PR TITLE
Fix forbidden Configurations Space

### DIFF
--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -70,20 +70,18 @@ cdef class AbstractForbiddenComponent(object):
         which takes an integer indicating which operation is to be performed,
         as follows:
         < 	0
-        == 2
+        ==      2
         > 	4
         <=	1
         !=	3
         >=	5
         """
         if self.value is None:
-            print(f"called this nasty None for {self.values}({type(self.values)}) {other.values}({type(other.values)}) ")
             self.value = self.values
         if other.value is None:
             other.value = other.values
 
         if isinstance(other, self.__class__):
-            print(f"called AbstractForbiddenComponent rich cmp ({self.value == other.value} AND {self.hyperparameter.name == other.hyperparameter.name}) {self.value}({type(self.value)}) {other.value}({type(other.value)})")
             if op == 2:
                 return (self.value == other.value
                          and self.hyperparameter.name == other.hyperparameter.name)
@@ -377,7 +375,6 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
             adifferent = [self.components[i] for i in range(self.n_components)]
             cdifferent = [other.components[i] for i in range(self.n_components)]
             bdifferent = [type(self.components[i]) for i in range(self.n_components)]
-            print(f"called rich cmp of forbidden with {op} self.n_components={self.n_components} other.n_components={other.n_components} {different} {adifferent}!={cdifferent} {bdifferent}")
             if op == 2:
                 if self.n_components != other.n_components:
                     return False

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -371,10 +371,6 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
         """
 
         if isinstance(other, self.__class__):
-            different = [self.components[i] == other.components[i] for i in range(self.n_components)]
-            adifferent = [self.components[i] for i in range(self.n_components)]
-            cdifferent = [other.components[i] for i in range(self.n_components)]
-            bdifferent = [type(self.components[i]) for i in range(self.n_components)]
             if op == 2:
                 if self.n_components != other.n_components:
                     return False

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -79,6 +79,7 @@ cdef class AbstractForbiddenComponent(object):
         if self.value is None:
             print(f"called this nasty None for {self.values}({type(self.values)}) {other.values}({type(other.values)}) ")
             self.value = self.values
+        if other.value is None:
             other.value = other.values
 
         if isinstance(other, self.__class__):

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -362,7 +362,7 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
         which takes an integer indicating which operation is to be performed,
         as follows:
         < 	0
-        == 2
+        ==      2
         > 	4
         <=	1
         !=	3
@@ -370,6 +370,10 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
         """
 
         if isinstance(other, self.__class__):
+            different = [self.components[i] == other.components[i] for i in range(self.n_components)]
+            adifferent = [self.components[i] for i in range(self.n_components)]
+            bdifferent = [type(self.components[i]) for i in range(self.n_components)]
+            print(f"called rich cmp of forbidden with {op} self.n_components={self.n_components} other.n_components={other.n_components} {different} {adifferent} {bdifferent}")
             if op == 2:
                 if self.n_components != other.n_components:
                     return False

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -77,10 +77,12 @@ cdef class AbstractForbiddenComponent(object):
         >=	5
         """
         if self.value is None:
+            print(f"called this nasty None for {self.values}({type(self.values)}) {other.values}({type(other.values)}) ")
             self.value = self.values
             other.value = other.values
 
         if isinstance(other, self.__class__):
+            print(f"called AbstractForbiddenComponent rich cmp ({self.value == other.value} AND {self.hyperparameter.name == other.hyperparameter.name}) {self.value}({type(self.value)}) {other.value}({type(other.value)})")
             if op == 2:
                 return (self.value == other.value
                          and self.hyperparameter.name == other.hyperparameter.name)
@@ -372,8 +374,9 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
         if isinstance(other, self.__class__):
             different = [self.components[i] == other.components[i] for i in range(self.n_components)]
             adifferent = [self.components[i] for i in range(self.n_components)]
+            cdifferent = [other.components[i] for i in range(self.n_components)]
             bdifferent = [type(self.components[i]) for i in range(self.n_components)]
-            print(f"called rich cmp of forbidden with {op} self.n_components={self.n_components} other.n_components={other.n_components} {different} {adifferent} {bdifferent}")
+            print(f"called rich cmp of forbidden with {op} self.n_components={self.n_components} other.n_components={other.n_components} {different} {adifferent}!={cdifferent} {bdifferent}")
             if op == 2:
                 if self.n_components != other.n_components:
                     return False

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -78,10 +78,10 @@ cdef class AbstractForbiddenComponent(object):
         """
         if self.value is None:
             self.value = self.values
-        if other.value is None:
-            other.value = other.values
 
         if isinstance(other, self.__class__):
+            if other.value is None:
+                other.value = other.values
             if op == 2:
                 return (self.value == other.value
                          and self.hyperparameter.name == other.hyperparameter.name)

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -377,7 +377,7 @@ cdef class AbstractForbiddenConjunction(AbstractForbiddenComponent):
                             for i in range(self.n_components)])
 
             elif op == 3:
-                if self.n_copmonents == other.n_components:
+                if self.n_components == other.n_components:
                     return False
                 return any([self.components[i] != other.components[i]
                             for i in range(self.n_components)])


### PR DESCRIPTION
I found a typo in the config space comparison, which would be great to fix.

But more importantly, in the parallel context objects might be re-created. There is an if below that basically sets up a value maybe if this is the first time a function is called. This has to be done separately, as the "other" config might be re-created while te "self" is not.