### PR TITLE
Fix compatibility for Python 3.9 gcd import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.6" RUN_FLAKE8="true"
     - DISTRIB="conda" PYTHON_VERSION="3.7" DOCPUSH="true" INSTALL_FROM_SDIST="true"
     - DISTRIB="conda" PYTHON_VERSION="3.8"
+    - DISTRIB="conda" PYTHON_VERSION="3.9"
   global:
     - TEST_DIR=/tmp/test_dir/
 

--- a/ConfigSpace/nx/algorithms/dag.py
+++ b/ConfigSpace/nx/algorithms/dag.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from math import gcd
+try:
+    from math import gcd # >= Python 3.9
+except ImportError:
+    from fractions import gcd # < Python 3.9
 
 import ConfigSpace.nx
 

--- a/ConfigSpace/nx/algorithms/dag.py
+++ b/ConfigSpace/nx/algorithms/dag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from fractions import gcd
+from math import gcd
 
 import ConfigSpace.nx
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ MIN_PYTHON_VERSION = '>=3.6'
 CLASSIFIERS = ['Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
                'Programming Language :: Python :: 3.8',
+               'Programming Language :: Python :: 3.9',
                'Development Status :: 4 - Beta',
                'Natural Language :: English',
                'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes issue #168: Python 3.9 support, gcd import

## Changes
Attempts `from math import gcd` which works for `>= Python 3.9` and defaults to `from fractions import gcd` if it fails.
Updates `.travis.yml` build matrix and `setup.py` meta-data. 

## Testing
Manually passed `pytest` with:
`Python 3.9.0` | `pip 20.2.3`
`Python 3.8.6` | `pip 20.2.1`
This pull request should then also initiate a full build for the other versions.

## Other
I found no mention of versioning in the docs, so no changes were done there.

 