### PR TITLE
[FIX] Cleanup ConfigSpace warnings

### DIFF
--- a/ConfigSpace/c_util.pyx
+++ b/ConfigSpace/c_util.pyx
@@ -18,7 +18,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.float
+DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/ConfigSpace/conditions.pxd
+++ b/ConfigSpace/conditions.pxd
@@ -6,7 +6,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.float
+DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/ConfigSpace/conditions.pyx
+++ b/ConfigSpace/conditions.pyx
@@ -46,7 +46,7 @@ from ConfigSpace.hyperparameters cimport Hyperparameter
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-# DTYPE = np.float
+# DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/ConfigSpace/conditions.pyx
+++ b/ConfigSpace/conditions.pyx
@@ -43,14 +43,6 @@ import numpy as np
 from ConfigSpace.hyperparameters import NumericalHyperparameter, OrdinalHyperparameter
 from ConfigSpace.hyperparameters cimport Hyperparameter
 
-# We now need to fix a datatype for our arrays. I've used the variable
-# DTYPE for this, which is assigned to the usual NumPy runtime
-# type info object.
-# DTYPE = float
-# "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
-# every type in the numpy module there's a corresponding compile-time
-# type with a _t-suffix.
-# ctypedef np.float_t DTYPE_t
 cimport numpy as np
 
 

--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1416,7 +1416,7 @@ class Configuration(object):
 
             self._query_values = True
             self._vector = np.ndarray((self._num_hyperparameters,),
-                                      dtype=np.float)
+                                      dtype=float)
 
             # Populate the vector
             # TODO very unintuitive calls...

--- a/ConfigSpace/forbidden.pxd
+++ b/ConfigSpace/forbidden.pxd
@@ -6,7 +6,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.float
+DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -37,14 +37,6 @@ from typing import List, Dict, Any, Union
 
 from ConfigSpace.forbidden cimport AbstractForbiddenComponent
 
-# We now need to fix a datatype for our arrays. I've used the variable
-# DTYPE for this, which is assigned to the usual NumPy runtime
-# type info object.
-# DTYPE = float
-# "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
-# every type in the numpy module there's a corresponding compile-time
-# type with a _t-suffix.
-# ctypedef float_t DTYPE_t
 from libc.stdlib cimport malloc, free
 cimport numpy as np
 

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -40,11 +40,11 @@ from ConfigSpace.forbidden cimport AbstractForbiddenComponent
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-# DTYPE = np.float
+# DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.
-# ctypedef np.float_t DTYPE_t
+# ctypedef float_t DTYPE_t
 from libc.stdlib cimport malloc, free
 cimport numpy as np
 

--- a/ConfigSpace/hyperparameters.pxd
+++ b/ConfigSpace/hyperparameters.pxd
@@ -6,7 +6,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.float
+DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -37,15 +37,6 @@ from typing import List, Any, Dict, Union, Set, Tuple, Optional
 import numpy as np
 cimport numpy as np
 
-# We now need to fix a datatype for our arrays. I've used the variable
-# DTYPE for this, which is assigned to the usual NumPy runtime
-# type info object.
-# DTYPE = float
-# "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
-# every type in the numpy module there's a corresponding compile-time
-# type with a _t-suffix.
-# ctypedef np.float_t DTYPE_t
-
 
 cdef class Hyperparameter(object):
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -40,7 +40,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-# DTYPE = np.float
+# DTYPE = float
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.
@@ -877,7 +877,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
         if self.log:
             repr_str.write(", on log-scale")
         if self.q is not None:
-            repr_str.write(", Q: %s" % repr(np.int(self.q)))
+            repr_str.write(", Q: %s" % repr(np.int64(self.q)))
         repr_str.seek(0)
         return repr_str.getvalue()
 
@@ -913,7 +913,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
         return self.ufhp._inverse_transform(vector)
 
     def is_legal(self, value: int) -> bool:
-        if not (isinstance(value, (int, np.int, np.int32, np.int64))):
+        if not (isinstance(value, (int, np.int32, np.int64))):
             return False
         elif self.upper >= value >= self.lower:
             return True
@@ -1174,7 +1174,7 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
                                             q=self.q, log=self.log)
 
     def is_legal(self, value: int) -> bool:
-        return isinstance(value, (int, np.int, np.int32, np.int64))
+        return isinstance(value, (int, np.int32, np.int64))
 
     cpdef bint is_legal_vector(self, DTYPE_t value):
         return isinstance(value, float) or isinstance(value, int)

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -868,7 +868,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
         if self.log:
             repr_str.write(", on log-scale")
         if self.q is not None:
-            repr_str.write(", Q: %s" % repr(np.int64(self.q)))
+            repr_str.write(", Q: %s" % repr(self.q))
         repr_str.seek(0)
         return repr_str.getvalue()
 

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -63,7 +63,7 @@ pp_floatorint = pp_float | pp_int
 pp_e_notation = pyparsing.Combine(pp_floatorint + pp_eorE + pp_int)
 pp_number = pp_e_notation | pp_float | pp_int
 pp_numberorname = pp_number | pp_param_name
-pp_log = pyparsing.Word("log")
+pp_log = pyparsing.Literal("log")
 # A word matches each character as a set. So && is processed as &
 # https://pythonhosted.org/pyparsing/pyparsing.Word-class.html
 pp_connective = pyparsing.Word("|" + "&")

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -66,7 +66,8 @@ pp_numberorname = pp_number | pp_param_name
 pp_log = pyparsing.Literal("log")
 # A word matches each character as a set. So && is processed as &
 # https://pythonhosted.org/pyparsing/pyparsing.Word-class.html
-pp_connective = pyparsing.Word("|" + "&")
+pp_connectiveOR = pyparsing.Literal("||")
+pp_connectiveAND = pyparsing.Literal("&&")
 pp_choices = pp_param_name + pyparsing.Optional(pyparsing.OneOrMore("," + pp_param_name))
 pp_sequence = pp_param_name + pyparsing.Optional(pyparsing.OneOrMore("," + pp_param_name))
 pp_ord_param = pp_param_name + pp_param_type + "{" + pp_sequence + "}" + "[" + pp_param_name + "]"
@@ -79,7 +80,7 @@ pp_condition = pp_param_name + "|" + pp_param_name + pp_param_operation + \
     pyparsing.Optional('{') + pp_param_val + pyparsing.Optional('}') + \
     pyparsing.Optional(
         pyparsing.OneOrMore(
-            pp_connective + pp_param_name + pp_param_operation
+            (pp_connectiveAND | pp_connectiveOR) + pp_param_name + pp_param_operation
             + pyparsing.Optional('{') + pp_param_val + pyparsing.Optional('}')
         )
     )

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -64,7 +64,9 @@ pp_e_notation = pyparsing.Combine(pp_floatorint + pp_eorE + pp_int)
 pp_number = pp_e_notation | pp_float | pp_int
 pp_numberorname = pp_number | pp_param_name
 pp_log = pyparsing.Word("log")
-pp_connective = pyparsing.Word("||" + "&&")
+# A word matches each character as a set. So && is processed as &
+# https://pythonhosted.org/pyparsing/pyparsing.Word-class.html
+pp_connective = pyparsing.Word("|" + "&")
 pp_choices = pp_param_name + pyparsing.Optional(pyparsing.OneOrMore("," + pp_param_name))
 pp_sequence = pp_param_name + pyparsing.Optional(pyparsing.OneOrMore("," + pp_param_name))
 pp_ord_param = pp_param_name + pp_param_type + "{" + pp_sequence + "}" + "[" + pp_param_name + "]"

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1105,3 +1105,36 @@ class TestHyperparameters(unittest.TestCase):
         f1.rvs(random_state=np.random)
         f1.rvs(random_state=np.random.default_rng(1))
         self.assertRaises(ValueError, f1.rvs, 1, "a")
+
+    def test_hyperparam_representation(self):
+        # Float
+        f1 = UniformFloatHyperparameter("param", 1, 100, log=True)
+        self.assertEqual(
+            "param, Type: UniformFloat, Range: [1.0, 100.0], Default: 10.0, on log-scale",
+            repr(f1)
+        )
+        f2 = NormalFloatHyperparameter("param", 8, 99.1, log=False)
+        self.assertEqual(
+            "param, Type: NormalFloat, Mu: 8.0 Sigma: 99.1, Default: 8.0",
+            repr(f2)
+        )
+        i1 = UniformIntegerHyperparameter("param", 0, 100)
+        self.assertEqual(
+            "param, Type: UniformInteger, Range: [0, 100], Default: 50",
+            repr(i1)
+        )
+        i2 = NormalIntegerHyperparameter("param", 5, 8)
+        self.assertEqual(
+            "param, Type: NormalInteger, Mu: 5 Sigma: 8, Default: 5",
+            repr(i2)
+        )
+        o1 = OrdinalHyperparameter("temp", ["freezing", "cold", "warm", "hot"])
+        self.assertEqual(
+            "temp, Type: Ordinal, Sequence: {freezing, cold, warm, hot}, Default: freezing",
+            repr(o1)
+        )
+        c1 = CategoricalHyperparameter("param", [True, False])
+        self.assertEqual(
+            "param, Type: Categorical, Choices: {True, False}, Default: True",
+            repr(c1)
+        )


### PR DESCRIPTION
This PR aims to remove every warning from configspace (so we have a full green pytest run).

This is done by:

- Removing pyparsing warnings
`/home/chico/.local/lib/python3.8/site-packages/pyparsing.py:3190: FutureWarning: Possible set intersection at position 3
`
- Removing the deprecation warnings from numpy
```
<google-sheets-html-origin><style type="text/css"><!--br {mso-data-placement:same-cell;}--></style>
Config space deprecation warnings regarding np.float/np.bool
--
cated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
cationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted    the numpy scalar type, use `np.float64` here.
cationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may    wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
rootdir: /home/chico/work/ConfigSpace_fork_removedeprecation

</google-sheets-html-origin>
```