### PR TITLE
Check new neighbors deterministically

### DIFF
--- a/ConfigSpace/util.pyx
+++ b/ConfigSpace/util.pyx
@@ -215,7 +215,7 @@ def get_one_exchange_neighbourhood(
                     # Only rigorously check every tenth configuration (
                     # because moving around in the neighborhood should
                     # just work!)
-                    if np.random.random() > 0.95:
+                    if random.random() > 0.95:
                         new_configuration.is_valid_configuration()
                     else:
                         configuration_space._check_forbidden(new_array)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -103,14 +103,14 @@ class UtilTest(unittest.TestCase):
         hp = UniformFloatHyperparameter('a', 1, 10)
         all_neighbors = self._test_get_one_exchange_neighbourhood(hp)
         all_neighbors = [neighbor['a'] for neighbor in all_neighbors]
-        self.assertAlmostEqual(5.44, np.mean(all_neighbors), places=2)
-        self.assertAlmostEqual(3.065, np.var(all_neighbors), places=2)
+        self.assertAlmostEqual(5.49, np.mean(all_neighbors), places=2)
+        self.assertAlmostEqual(3.192, np.var(all_neighbors), places=2)
         hp = UniformFloatHyperparameter('a', 1, 10, log=True)
         all_neighbors = self._test_get_one_exchange_neighbourhood(hp)
         all_neighbors = [neighbor['a'] for neighbor in all_neighbors]
         # Default value is 3.16
-        self.assertAlmostEqual(3.45, np.mean(all_neighbors), places=2)
-        self.assertAlmostEqual(2.67, np.var(all_neighbors), places=2)
+        self.assertAlmostEqual(3.50, np.mean(all_neighbors), places=2)
+        self.assertAlmostEqual(2.79, np.var(all_neighbors), places=2)
 
     def test_random_neighbor_int(self):
         hp = UniformIntegerHyperparameter('a', 1, 10)


### PR DESCRIPTION
One-exchange neighborhood iterator rigorously checks some of the generated configurations. The check is performed with the probability 5 %, as decided by `np.random`.

Make the check deterministic (using an explicitly seeded `np.random.RandomState`) instead of relying on the default numpy random state, which need not be seeded.

Resolves #194.