### PR TITLE
Make print(config) friendlier for copy-paste

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,10 @@ jobs:
       run: |
         cd docs
         make html
+    - name: Run doctests
+      run: |
+        cd docs
+        make doctest
     - name: Pull latest gh-pages
       if: (contains(github.ref, 'master')) && github.event_name == 'push'
       run: |

--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1573,7 +1573,7 @@ class Configuration(collections.abc.Mapping):
         self._populate_values()
 
         representation = io.StringIO()
-        representation.write("Configuration:\n")
+        representation.write("Configuration(values={\n")
 
         hyperparameters = self.configuration_space.get_hyperparameters()
         hyperparameters.sort(key=lambda t: t.name)
@@ -1581,14 +1581,10 @@ class Configuration(collections.abc.Mapping):
             hp_name = hyperparameter.name
             if hp_name in self._values and self._values[hp_name] is not None:
                 representation.write("  ")
-
                 value = repr(self._values[hp_name])
-                if isinstance(hyperparameter, Constant):
-                    representation.write("%s, Constant: %s" % (hp_name, value))
-                else:
-                    representation.write("%s, Value: %s" % (hp_name, value))
-                representation.write("\n")
+                representation.write("'%s': %s,\n" % (hp_name, value))
 
+        representation.write("})\n")
         return representation.getvalue()
 
     def __iter__(self) -> Iterable:

--- a/docs/source/User-Guide.rst
+++ b/docs/source/User-Guide.rst
@@ -49,9 +49,10 @@ For demonstration  purpose, we sample a configuration from it.
     >>> cs.add_hyperparameters([c, max_iter])
     [C, Type: UniformFloat, Range: [-1.0, 1.0], Default: 0.0, max_iter, Type: ...]
     >>> cs.sample_configuration()
-    Configuration:
-      C, Value: -0.6169610992422154
-      max_iter, Value: 66
+    Configuration(values={
+      'C': -0.6169610992422154,
+      'max_iter': 66,
+    })
     <BLANKLINE>
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-    'sphinx.ext.githubpages'
+    'sphinx.ext.githubpages',
+    'sphinx.ext.doctest',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,9 +44,10 @@ Basic usage
     >>> cs.add_hyperparameters([a, b])
     [a, Type: UniformInteger, Range: [10, 100], Default: 55,...]
     >>> cs.sample_configuration()
-    Configuration:
-      a, Value: 27
-      b, Value: 'blue'
+    Configuration(values={
+      'a': 27,
+      'b': 'blue',
+    })
     <BLANKLINE>
 
 Installation

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -57,8 +57,9 @@ For demonstration purpose, we sample a configuration from the :class:`~ConfigSpa
 .. doctest::
 
     >>> cs.sample_configuration()
-    Configuration:
-      alpha, Value: 0.1915194503788923
+    Configuration(values={
+      'alpha': 0.1915194503788923,
+    })
     <BLANKLINE>
 
 And that's it.

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -1044,3 +1044,18 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(parent.get_hyperparameter("sub:chp").meta, dict(chp=True))
         self.assertEqual(parent.get_hyperparameter("sub:ohp").meta, dict(ohp=True))
         self.assertEqual(parent.get_hyperparameter("sub:const").meta, dict(const=True))
+
+    def test_repr_roundtrip(self):
+        cs = ConfigurationSpace()
+        cs.add_hyperparameter(UniformIntegerHyperparameter("uihp", lower=1, upper=10))
+        cs.add_hyperparameter(NormalIntegerHyperparameter("nihp", mu=0, sigma=1))
+        cs.add_hyperparameter(UniformFloatHyperparameter("ufhp", lower=1, upper=10))
+        cs.add_hyperparameter(NormalFloatHyperparameter("nfhp", mu=0, sigma=1))
+        cs.add_hyperparameter(CategoricalHyperparameter("chp", choices=['1', '2', '3']))
+        cs.add_hyperparameter(OrdinalHyperparameter("ohp", sequence=['1', '2', '3']))
+        cs.add_hyperparameter(Constant("const", value=1))
+        default = cs.get_default_configuration()
+        repr = default.__repr__()
+        repr = repr.replace('})', '}, configuration_space=cs)')
+        config = eval(repr)
+        self.assertEqual(default, config)


### PR DESCRIPTION
Implements #66.

Configurations are now printed as
```
Configuration(values={
  'chp': '1',
  'const': 1,
  'nfhp': 0.0,
  'nihp': 0,
  'ohp': '1',
  'ufhp': 5.5,
  'uihp': 6,
})
```
opposed to
```
Configuration:
  chp, Value: '1'
  const, Constant: 1
  nfhp, Value: 0.0
  nihp, Value: 0
  ohp, Value: '1'
  ufhp, Value: 5.5
  uihp, Value: 6
```
.

This does not yet allow for copy-pasting the configuration as the argument `configuration_space` is not printed, but it is much closer. Yet another alternative would be
```
{
  'chp': '1',
  'const': 1,
  'nfhp': 0.0,
  'nihp': 0,
  'ohp': '1',
  'ufhp': 5.5,
  'uihp': 6,
}
```
which could be used as the `values` argument to `Configuration`.

If there are any other suggestions I would be happy to hear about them.

CC @eddiebergman @KEggensperger @dengdifan @renesass @mlindauer @RaghuSpaceRajan 