### PR TITLE
Fixes equality with ordering of hyperparameters

### DIFF
--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1470,7 +1470,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
 
         return (
             self.name == other.name and
-            self.choices == other.choices
+            set(self.choices) == set(other.choices)
         )
 
     def __hash__(self):

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -551,6 +551,11 @@ class TestHyperparameters(unittest.TestCase):
         self.assertNotEqual(f1, f2)
         self.assertNotEqual(f1, "UniformFloat")
 
+        # Test that order of categoricals does not matter
+        f7 = CategoricalHyperparameter("param", ["a", "b"])
+        f7_ = CategoricalHyperparameter("param", ["b", "a"])
+        assert f7 == f7_
+
         # test that meta-data is stored correctly
         f_meta = CategoricalHyperparameter("param", ["a", "b"], default_value="a",
                                            meta=dict(self.meta_data))


### PR DESCRIPTION
Fixes #73 in which the following use to be false but is fixed to be true.

```python
f7 = CategoricalHyperparameter("param", ["a", "b"])
f7_ = CategoricalHyperparameter("param", ["b", "a"])
assert f7 == f7_
```