### PR TITLE
Fix double github action test triggers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,8 +14,8 @@ jobs:
     name: Unit-tests for cp${{ matrix.python }}-${{ matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         use-conda: [true, false]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   # Allow to manually trigger through github API
   workflow_dispatch:
-
   # Triggers with push to master
   push:
     branches:
@@ -110,9 +109,10 @@ jobs:
       run: |
         if [[ ${{ matrix.kind }} == 'conda' ]]; then
           PYTHON=$CONDA/envs/testenv/bin/python3
-        else:
+        else
           PYTHON=$(which python3)
         fi
+
         if [ ${{ matrix.code-cov }} ]; then
           $PYTHON -m pytest ${{ env.pytest-args }} ${{ env.code-cov-args }} test
         else

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
   schedule:
@@ -8,31 +9,41 @@ on:
     - cron: '0 07 * * 5'
 
 jobs:
-  ubuntu:
+  unit-test:
 
-    runs-on: ubuntu-18.04
+    name: Unit-tests for cp${{ matrix.python }}-${{ matrix.os}}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        fail-fast: false
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         use-conda: [true, false]
         use-dist: [false]
         include:
-          - python-version: 3.8
+
+          - os: ubuntu-latest
+            python-version: "3.8"
             code-cov: true
-          - python-version: 3.7
+
+          - os: ubuntu-latest
+            python-version: "3.7"
             use-conda: false
             use-dist: true
-      fail-fast:  false
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+
       # A note on checkout: When checking out the repository that
       # triggered a workflow, this defaults to the reference or SHA for that event.
       # Otherwise, uses the default branch (master) is used.
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Conda Install test dependencies
       if: matrix.use-conda == true
       run: |
@@ -40,29 +51,27 @@ jobs:
         $CONDA/bin/conda create -n testenv --yes pip wheel python=${{ matrix.python-version }}
         $CONDA/envs/testenv/bin/python3 -m pip install --upgrade pip
         $CONDA/envs/testenv/bin/pip3 install -e .[test]
+
     - name: Install test dependencies
       if: matrix.use-conda == false && matrix.use-dist == false
       run: |
         python -m pip install --upgrade pip
-        if [[ `python -c 'import platform; print(platform.python_version())' | cut -d '.' -f 2` -eq 6 ]]; then
-          # Numpy 1.20 dropped suppert for Python3.6
-          pip install "numpy<=1.19"
-        fi
         pip install -e .[test]
-        sudo apt-get update
+
     - name: Dist Install test dependencies
       if: matrix.use-conda == false && matrix.use-dist == true
       run: |
         python -m pip install --upgrade pip
-        sudo apt-get update
         # We need to install for the dependencies, like pytest
         python setup.py sdist
         last_dist=$(ls -t dist/ConfigSpace-*.tar.gz | head -n 1)
         pip install $last_dist[test]
+
     - name: Store repository status
       id: status-before
       run: |
         echo "::set-output name=BEFORE::$(git status --porcelain -b)"
+
     - name: Conda Run tests
       timeout-minutes: 45
       if: matrix.use-conda == true
@@ -70,12 +79,14 @@ jobs:
         export PATH="$CONDA/envs/testenv/bin:$PATH"
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=ConfigSpace --cov-report=xml'; fi
         $CONDA/envs/testenv/bin/python3 -m pytest --durations=20  -v $codecov test
+
     - name: Run tests
       timeout-minutes: 45
       if: matrix.use-conda == false
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=ConfigSpace --cov-report=xml'; fi
         pytest --durations=20 -v $codecov test
+
     - name: Check for files left behind by test
       if: ${{ always() }}
       run: |
@@ -87,6 +98,7 @@ jobs:
             echo "Not all generated files have been deleted!"
             exit 1
         fi
+
     - name: Upload coverage
       if: matrix.code-cov && always()
       uses: codecov/codecov-action@v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ on:
   # Triggers with push to a pr aimed at master
   pull_request:
     branches:
-      - main:
+      - master
 
   schedule:
     # Every Monday at 7AM UTC

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -95,6 +95,7 @@ jobs:
       if: matrix.kind == 'dist'
       run: |
         python -m pip install --upgrade pip
+        sudo apt-get update
         python setup.py sdist
         last_dist=$(ls -t dist/ConfigSpace-*.tar.gz | head -n 1)
         pip install $last_dist[test]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -95,7 +95,6 @@ jobs:
       if: matrix.kind == 'dist'
       run: |
         python -m pip install --upgrade pip
-        sudo apt-get update
         python setup.py sdist
         last_dist=$(ls -t dist/ConfigSpace-*.tar.gz | head -n 1)
         python -m pip install $last_dist[test]
@@ -109,15 +108,13 @@ jobs:
       timeout-minutes: 45
       run: |
         if [[ ${{ matrix.kind }} == 'conda' ]]; then
-          PYTHON=$CONDA/envs/testenv/bin/python3
-        else
-          PYTHON=$(which python)
+          export PATH="$CONDA/envs/testenv/bin:$PATH"
         fi
 
         if [ ${{ matrix.code-cov }} ]; then
-          $PYTHON -m pytest ${{ env.pytest-args }} ${{ env.code-cov-args }} test
+          pytest ${{ env.pytest-args }} ${{ env.code-cov-args }} test
         else
-          $PYTHON -m pytest ${{ env.pytest-args }} test
+          pytest ${{ env.pytest-args }} test
         fi
 
     - name: Check for files left behind by test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ env:
 jobs:
 
   unit-test:
-    name: ${{ matrix.python }}-${{ matrix.os }}-${{ matrix.kind }}
+    name: ${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.kind }}
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  # Allow to manually trigger through github API
   workflow_dispatch:
 
   # Triggers with push to master
@@ -14,31 +15,55 @@ on:
       - master
 
   schedule:
-    # Every Monday at 7AM UTC
-    - cron: '0 07 * * 5'
+    # Every day at 7AM UTC
+    - cron: '0 07 * * *'
+
+env:
+
+  # Arguments used for pytest
+  pytest-args: >-
+    --durations=20
+    -v
+
+  # Arguments used for code-cov which is later used to annotate PR's on github
+  code-cov-args: >-
+    --cov=ConfigSpace
+    --cov-report=xml
 
 jobs:
-  unit-test:
 
-    name: Unit-tests for cp${{ matrix.python }}-${{ matrix.os}}
+  unit-test:
+    name: ${{ matrix.python }}-${{ matrix.os }}-${{ matrix.kind }}
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        use-conda: [true, false]
-        use-dist: [false]
-        include:
+        kind: ['conda', 'source', 'dist']
 
+        exclude:
+          # Exclude all configurations *-*-dist, include one later
+          - kind: 'dist'
+
+          # Exclude windows as bash commands wont work in windows runner
+          - os: windows-latest
+
+          # Exclude macos as there are permission errors using conda as we do
+          - os: macos-latest
+
+        include:
+          # Add the tag code-cov to ubuntu-3.7-source
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: 3.7
+            kind: 'source'
             code-cov: true
 
+          # Include one config with dist, ubuntu-3.7-dist
           - os: ubuntu-latest
-            python-version: "3.7"
-            use-conda: false
-            use-dist: true
+            python-version: 3.7
+            kind: 'dist'
 
     steps:
 
@@ -53,48 +78,46 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Conda Install test dependencies
-      if: matrix.use-conda == true
+    - name: Conda install
+      if: matrix.kind == 'conda'
       run: |
         # Miniconda is available in $CONDA env var
         $CONDA/bin/conda create -n testenv --yes pip wheel python=${{ matrix.python-version }}
         $CONDA/envs/testenv/bin/python3 -m pip install --upgrade pip
         $CONDA/envs/testenv/bin/pip3 install -e .[test]
 
-    - name: Install test dependencies
-      if: matrix.use-conda == false && matrix.use-dist == false
+    - name: Source install
+      if: matrix.kind == 'source'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
 
-    - name: Dist Install test dependencies
-      if: matrix.use-conda == false && matrix.use-dist == true
+    - name: Dist install
+      if: matrix.kind == 'dist'
       run: |
         python -m pip install --upgrade pip
-        # We need to install for the dependencies, like pytest
         python setup.py sdist
         last_dist=$(ls -t dist/ConfigSpace-*.tar.gz | head -n 1)
         pip install $last_dist[test]
 
-    - name: Store repository status
+    - name: Store git status
       id: status-before
       run: |
         echo "::set-output name=BEFORE::$(git status --porcelain -b)"
 
-    - name: Conda Run tests
+    - name: Tests
       timeout-minutes: 45
-      if: matrix.use-conda == true
       run: |
-        export PATH="$CONDA/envs/testenv/bin:$PATH"
-        if [ ${{ matrix.code-cov }} ]; then codecov='--cov=ConfigSpace --cov-report=xml'; fi
-        $CONDA/envs/testenv/bin/python3 -m pytest --durations=20  -v $codecov test
-
-    - name: Run tests
-      timeout-minutes: 45
-      if: matrix.use-conda == false
-      run: |
-        if [ ${{ matrix.code-cov }} ]; then codecov='--cov=ConfigSpace --cov-report=xml'; fi
-        pytest --durations=20 -v $codecov test
+        if [[ ${{ matrix.kind }} == 'conda' ]]; then
+          PYTHON=$CONDA/envs/testenv/bin/python3
+        else:
+          PYTHON=$(which python3)
+        fi
+        if [ ${{ matrix.code-cov }} ]; then
+          $PYTHON -m pytest ${{ env.pytest-args }} ${{ env.code-cov-args }} test
+        else
+          $PYTHON -m pytest ${{ env.pytest-args }} test
+        fi
 
     - name: Check for files left behind by test
       if: ${{ always() }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,7 +98,7 @@ jobs:
         sudo apt-get update
         python setup.py sdist
         last_dist=$(ls -t dist/ConfigSpace-*.tar.gz | head -n 1)
-        pip install $last_dist[test]
+        python -m pip install $last_dist[test]
 
     - name: Store git status
       id: status-before
@@ -111,7 +111,7 @@ jobs:
         if [[ ${{ matrix.kind }} == 'conda' ]]; then
           PYTHON=$CONDA/envs/testenv/bin/python3
         else
-          PYTHON=$(which python3)
+          PYTHON=$(which python)
         fi
 
         if [ ${{ matrix.code-cov }} ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,8 +2,17 @@ name: Tests
 
 on:
   workflow_dispatch:
+
+  # Triggers with push to master
   push:
+    branches:
+      - master
+
+  # Triggers with push to a pr aimed at master
   pull_request:
+    branches:
+      - main:
+
   schedule:
     # Every Monday at 7AM UTC
     - cron: '0 07 * * 5'


### PR DESCRIPTION
* Adds windows and osx to the `pytest` workflows but have them disabled.
* Removes double trigger of tests with each push to a PR
* Add manual trigger `workflow_dispatch`
* Make the file a bit cleaner, removing unneeded code