### PR TITLE
Betaparams

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -41,6 +41,9 @@ from ConfigSpace.hyperparameters import (
     Hyperparameter,
     Constant,
     FloatHyperparameter,
+    UniformFloatHyperparameter,
+    UniformIntegerHyperparameter,
+    OrdinalHyperparameter
 )
 from ConfigSpace.conditions import (
     ConditionComponent,
@@ -1341,6 +1344,19 @@ class ConfigurationSpace(collections.abc.Mapping):
         """
         self.random = np.random.RandomState(seed)
 
+    def to_uniform(self) -> 'ConfigurationSpace':
+        uniform_config_space = ConfigurationSpace()
+        for parameter in self.get_hyperparameters():
+            if type(parameter) not in [UniformFloatHyperparameter, UniformIntegerHyperparameter, OrdinalHyperparameter]:
+                uniform_config_space.add_hyperparameter(parameter.to_uniform())
+            else:
+                uniform_config_space.add_hyperparameter(parameter)
+
+        # TODO - check that this is certainly correct    
+        uniform_config_space.add_conditions(self.get_conditions())
+        uniform_config_space.add_forbidden_clauses(self.get_forbiddens())
+        
+        return uniform_config_space
 
 class Configuration(collections.abc.Mapping):
     def __init__(self, configuration_space: ConfigurationSpace,

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -869,37 +869,16 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             vector = np.log(vector)
         return vector
 
+    def get_neighbors(self, value: float, rs: np.random.RandomState, number: int = 4,
+                      transform: bool = False) -> List[float]:
+        neighbors = []
+        for i in range(number):
+            new_value = rs.normal(value, self.sigma)
 
-    def get_neighbors(
-        self,
-        value: Union[int, float],
-        rs: np.random.RandomState,
-        number: int = 4,
-        transform: bool = False,
-    ) -> List[Union[np.ndarray, float, int]]:
-        neighbors = []  # type: List[Union[np.ndarray, float, int]]
-        while len(neighbors) < number:
-            rejected = True
-            iteration = 0
-            while rejected:
-                iteration += 1
-                new_value = rs.normal(value, self.sigma)
-                int_value = self._transform(value)
-                new_int_value = self._transform(new_value)
+            if self.lower is not None and self.upper is not None:
+                    new_value = min(max(new_value, self.lower), self.upper)
 
-                if self.lower is not None and self.upper is not None:
-                    int_value = min(max(int_value, self.lower), self.upper)
-                    new_int_value = min(max(new_int_value, self.lower), self.upper)
-
-                if int_value != new_int_value:
-                    rejected = False
-                elif iteration > 100000:
-                    raise ValueError('Probably caught in an infinite loop.')
-
-            if transform:
-                neighbors.append(self._transform(new_value))
-            else:
-                neighbors.append(new_value)
+            neighbors.append(new_value)
         return neighbors
 
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -811,7 +811,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         else:
             raise ValueError("Illegal default value %s" % str(default_value))
 
-    def to_integer(self) -> NormalIntegerHyperparameter:
+    def to_integer(self) -> 'NormalIntegerHyperparameter':
         if self.q is None:
             q_int = None
         else:
@@ -1058,7 +1058,7 @@ cdef class BetaFloatHyperparameter(FloatHyperparameter):
     def __hash__(self):
         return hash((self.name, self.alpha, self.beta, self.log, self.q))
 
-    def to_uniform(self) -> UniformFloatHyperparameter:
+    def to_uniform(self) -> 'UniformFloatHyperparameter':
         lb = self.lower
         ub = self.upper
 
@@ -1088,7 +1088,7 @@ cdef class BetaFloatHyperparameter(FloatHyperparameter):
         else:
             raise ValueError("Illegal default value %s" % str(default_value))
 
-    def to_integer(self) -> BetaIntegerHyperparameter:
+    def to_integer(self) -> 'BetaIntegerHyperparameter':
         if self.q is None:
             q_int = None
         else:
@@ -2152,7 +2152,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
 
     # TODO review the name for this - it's just for producing a categorical hyperparameter
     # with equal weights for all choices
-    def to_uniform(self):
+    def to_uniform(self) -> 'CategoricalHyperparameter':
         return CategoricalHyperparameter(
             name=self.name,
             choices=copy.deepcopy(self.choices),

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -898,9 +898,6 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
 
 
-# and this one if for defining custom discrete distributions over some space 
-# with the combination of the two, you can design most reasonable probability distributions
-# TODO - implement
 cdef class BetaFloatHyperparameter(FloatHyperparameter):
     cdef public alpha
     cdef public beta
@@ -1600,7 +1597,6 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
             meta=self.meta
         )
 
-    # todo check if conversion should be done in initiation call or inside class itsel
     def to_uniform(self, z: int = 3) -> 'UniformIntegerHyperparameter':
         if self.lower is None or self.upper is None:
             lb = np.round(int(self.mu - (z * self.sigma)))
@@ -1705,9 +1701,6 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
         return self.nfhp._pdf(vector) / self.normalization_constant
 
 
-# and this one if for defining custom discrete distributions over some space 
-# with the combination of the two, you can design most reasonable probability distributions
-# TODO - implement
 cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
     cdef public alpha
     cdef public beta
@@ -1865,7 +1858,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
             meta=self.meta
         )
 
-    # todo check if conversion should be done in initiation call or inside class itsel
     def to_uniform(self, z: int = 3) -> 'UniformIntegerHyperparameter':
         lb = self.lower
         ub = self.upper
@@ -2016,7 +2008,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
         return self.bfhp._pdf(vector) / self.normalization_constant
 
 
-# TODO - implement .pdf method
 cdef class CategoricalHyperparameter(Hyperparameter):
     cdef public tuple choices
     cdef public tuple probabilities
@@ -2143,8 +2134,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             meta=self.meta
         )
 
-    # TODO review the name for this - it's just for producing a categorical hyperparameter
-    # with equal weights for all choices
+    # This is just for the uniform configspace for PiBO
+    # It creates a categorical parameter with equal weights for all choices
     def to_uniform(self) -> 'CategoricalHyperparameter':
         return CategoricalHyperparameter(
             name=self.name,
@@ -2238,8 +2229,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             return None
 
 
-    # TODO - encountered something of a bug here when this was passed through .pdf
-    # for some reason, it wanted a numpy array as output
+    # TEncountered something of a bug here when this was passed through .pdf
+    # for some reason, it wanted a numpy array as output (and as such, it is now changed)
     def _inverse_transform(self, vector: Union[None, np.ndarray, str, float, int]) -> Union[np.ndarray, int, float]:
         if vector is None:
             return np.NaN
@@ -2302,7 +2293,6 @@ cdef class CategoricalHyperparameter(Hyperparameter):
         return self._pdf(vector)
 
 
-# TODO - implement .pdf method
 cdef class OrdinalHyperparameter(Hyperparameter):
     cdef public tuple sequence
     cdef public int num_elements

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -2011,14 +2011,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
         all_probabilities = self.bfhp.pdf(all_integer_values)
         return np.sum(all_probabilities)
 
-    # TODO remove
-    def get_probs(self):
-        upper = self.upper
-        lower = self.lower
-        all_integer_values = np.arange(self.lower, self.upper+1)
-        all_probabilities = self.bfhp.pdf(all_integer_values)
-        return all_integer_values, all_probabilities
-        
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         return self.bfhp._pdf(vector) / self.normalization_constant
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1997,7 +1997,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
 
         return neighbors
 
-        
     def _compute_normalization(self):
         # to use the same pdfs, transforms etc. (and have something that generalizes)
         # across discrete parameter types, we compute the pdf for the corresponding
@@ -2148,6 +2147,16 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             choices=copy.deepcopy(self.choices),
             default_value=self.default_value,
             weights=copy.deepcopy(self.probabilities),
+            meta=self.meta
+        )
+
+    # TODO review the name for this - it's just for producing a categorical hyperparameter
+    # with equal weights for all choices
+    def to_uniform(self):
+        return CategoricalHyperparameter(
+            name=self.name,
+            choices=copy.deepcopy(self.choices),
+            default_value=self.default_value,
             meta=self.meta
         )
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -883,14 +883,13 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         mu = self.mu
         sigma = self.sigma
         if self.lower == None:
-            return norm(loc=mu, scale=sigma).pdf(vector)
+            raise ValueError('Need upper and lower limits when using user priors.')
         else:
-            lower = self.lower
-            upper = self.upper
-            a = (lower - mu) / sigma
-            b = (upper - mu) / sigma
-            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
-
+            # regardless of whether we have log input or not, this yields the correct answer,
+            # as the data always comes in transformed
+            lower = self._lower
+            upper = self._upper
+            return truncnorm(lower, upper, loc=mu, scale=sigma).pdf(vector)
 
 
 # and this one if for defining custom discrete distributions over some space 

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -16,7 +16,8 @@ from ConfigSpace.hyperparameters import (
     OrdinalHyperparameter,
     Constant,
     UnParametrizedHyperparameter,
-    BetaFloatHyperparameter
+    BetaFloatHyperparameter,
+    BetaIntegerHyperparameter
 )
 from ConfigSpace.conditions import (
     AbstractCondition,
@@ -82,7 +83,7 @@ def _build_normal_float(param: NormalFloatHyperparameter) -> Dict:
 def _build_beta_float(param: BetaFloatHyperparameter) -> Dict:
     return {
         'name': param.name,
-        'type': 'normal_float',
+        'type': 'beta_float',
         'log': param.log,
         'alpha': param.alpha,
         'beta': param.beta,
@@ -108,6 +109,17 @@ def _build_normal_int(param: NormalIntegerHyperparameter) -> Dict:
         'log': param.log,
         'mu': param.mu,
         'sigma': param.sigma,
+        'default': param.default_value
+    }
+
+
+def _build_beta_int(param: BetaIntegerHyperparameter) -> Dict:
+    return {
+        'name': param.name,
+        'type': 'beta_int',
+        'log': param.log,
+        'alpha': param.alpha,
+        'beta': param.beta,
         'default': param.default_value
     }
 
@@ -338,6 +350,8 @@ def write(configuration_space, indent=2):
             hyperparameters.append(_build_uniform_int(hyperparameter))
         elif isinstance(hyperparameter, NormalIntegerHyperparameter):
             hyperparameters.append(_build_normal_int(hyperparameter))
+        elif isinstance(hyperparameter, BetaIntegerHyperparameter):
+            hyperparameters.append(_build_beta_int(hyperparameter))
         elif isinstance(hyperparameter, CategoricalHyperparameter):
             hyperparameters.append(_build_categorical(hyperparameter))
         elif isinstance(hyperparameter, OrdinalHyperparameter):

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -16,6 +16,7 @@ from ConfigSpace.hyperparameters import (
     OrdinalHyperparameter,
     Constant,
     UnParametrizedHyperparameter,
+    BetaFloatHyperparameter
 )
 from ConfigSpace.conditions import (
     AbstractCondition,
@@ -74,6 +75,17 @@ def _build_normal_float(param: NormalFloatHyperparameter) -> Dict:
         'log': param.log,
         'mu': param.mu,
         'sigma': param.sigma,
+        'default': param.default_value
+    }
+
+
+def _build_beta_float(param: BetaFloatHyperparameter) -> Dict:
+    return {
+        'name': param.name,
+        'type': 'normal_float',
+        'log': param.log,
+        'alpha': param.alpha,
+        'beta': param.beta,
         'default': param.default_value
     }
 
@@ -320,6 +332,8 @@ def write(configuration_space, indent=2):
             hyperparameters.append(_build_uniform_float(hyperparameter))
         elif isinstance(hyperparameter, NormalFloatHyperparameter):
             hyperparameters.append(_build_normal_float(hyperparameter))
+        elif isinstance(hyperparameter, BetaFloatHyperparameter):
+            hyperparameters.append(_build_beta_float(hyperparameter))
         elif isinstance(hyperparameter, UniformIntegerHyperparameter):
             hyperparameters.append(_build_uniform_int(hyperparameter))
         elif isinstance(hyperparameter, NormalIntegerHyperparameter):


### PR DESCRIPTION
### Added the beta parameter types, the accompanying imports and checks, and implemented the infrastructure for computing the pdf of a parameter

__hyperparameters__: 
- added BetaFloat and BetaIntegerHyperparameter - they share the neighbor generation of their uniform counterparts. 
- Added pdf and _pdf for all parameters, where the logic is
pdf(vector) = _pdf(inverse_transform(vector)). This means that the user can call pdf(X) on the original parameter range, but the acquisition function calls _pdf, since it already recieves the transformed parameter ranges.
- The Beta parameters are not normalized to 0-1 range, which is simply because Normal was not, either. Not sure if this is the correct choice.
- The local searches are just copy-paste of the corresponding Uniform parameter types - with the exception that the jump from existing configuration is scaled by the range of the parameter (as it it not in 0-1, the jump presumably needs to reflect this)

__json__: added the necessary stuff for the new parameters to fit in with the rest
__configuration_space__: Added a method to_uniform to create a ConfigSpace of only uniform parameters - needed for the new local search approach in SMAC (see ei_optimization)
