### PR TITLE
Betaparams merge

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -41,6 +41,9 @@ from ConfigSpace.hyperparameters import (
     Hyperparameter,
     Constant,
     FloatHyperparameter,
+    UniformFloatHyperparameter,
+    UniformIntegerHyperparameter,
+    OrdinalHyperparameter
 )
 from ConfigSpace.conditions import (
     ConditionComponent,
@@ -1341,6 +1344,19 @@ class ConfigurationSpace(collections.abc.Mapping):
         """
         self.random = np.random.RandomState(seed)
 
+    def to_uniform(self) -> 'ConfigurationSpace':
+        uniform_config_space = ConfigurationSpace()
+        for parameter in self.get_hyperparameters():
+            if type(parameter) not in [UniformFloatHyperparameter, UniformIntegerHyperparameter, OrdinalHyperparameter]:
+                uniform_config_space.add_hyperparameter(parameter.to_uniform())
+            else:
+                uniform_config_space.add_hyperparameter(parameter)
+
+        # TODO - check that this is certainly correct    
+        uniform_config_space.add_conditions(self.get_conditions())
+        uniform_config_space.add_forbidden_clauses(self.get_forbiddens())
+        
+        return uniform_config_space
 
 class Configuration(collections.abc.Mapping):
     def __init__(self, configuration_space: ConfigurationSpace,

--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1352,7 +1352,6 @@ class ConfigurationSpace(collections.abc.Mapping):
             else:
                 uniform_config_space.add_hyperparameter(parameter)
 
-        # TODO - check that this is certainly correct    
         uniform_config_space.add_conditions(self.get_conditions())
         uniform_config_space.add_forbidden_clauses(self.get_forbiddens())
         

--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1344,7 +1344,7 @@ class ConfigurationSpace(collections.abc.Mapping):
         """
         self.random = np.random.RandomState(seed)
 
-    def to_uniform(self) -> 'ConfigurationSpace':
+    def remove_parameter_priors(self) -> 'ConfigurationSpace':
         uniform_config_space = ConfigurationSpace()
         for parameter in self.get_hyperparameters():
             if type(parameter) not in [UniformFloatHyperparameter, UniformIntegerHyperparameter, OrdinalHyperparameter]:

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1646,7 +1646,12 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
                                               default_value=self.default_value)
 
         self.normalized_default_value = self._inverse_transform(self.default_value)
-        self.normalization_constant = self._compute_normalization()
+        
+        if (self.lower is None) or (self.upper is None):
+            # Since a bound is missing, the pdf cannot be normalized. Working with the unnormalized variant)
+            self.normalization_constant = 1
+        else:
+            self.normalization_constant = self._compute_normalization()
 
     def __repr__(self) -> str:
         repr_str = io.StringIO()
@@ -1810,6 +1815,16 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
 
     def get_max_density(self):
         return self.nfhp.get_max_density() / self.normalization_constant
+
+    def get_size(self) -> float:
+        if self.lower is None:
+            return np.inf
+        else:
+            if self.q is None:
+                q = 1
+            else:
+                q = self.q
+            return np.rint((self.upper - self.lower) / self.q) + 1
 
 
 cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
@@ -2120,16 +2135,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
 
     def get_max_density(self):
         return self.bfhp.get_max_density() / self.normalization_constant
-
-    def get_size(self) -> float:
-        if self.lower is None:
-            return np.inf
-        else:
-            if self.q is None:
-                q = 1
-            else:
-                q = self.q
-            return np.rint((self.upper - self.lower) / self.q) + 1
 
 
 cdef class CategoricalHyperparameter(Hyperparameter):

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -869,37 +869,16 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             vector = np.log(vector)
         return vector
 
+    def get_neighbors(self, value: float, rs: np.random.RandomState, number: int = 4,
+                      transform: bool = False) -> List[float]:
+        neighbors = []
+        for i in range(number):
+            new_value = rs.normal(value, self.sigma)
 
-    def get_neighbors(
-        self,
-        value: Union[int, float],
-        rs: np.random.RandomState,
-        number: int = 4,
-        transform: bool = False,
-    ) -> List[Union[np.ndarray, float, int]]:
-        neighbors = []  # type: List[Union[np.ndarray, float, int]]
-        while len(neighbors) < number:
-            rejected = True
-            iteration = 0
-            while rejected:
-                iteration += 1
-                new_value = rs.normal(value, self.sigma)
-                int_value = self._transform(value)
-                new_int_value = self._transform(new_value)
+            if self.lower is not None and self.upper is not None:
+                    new_value = min(max(new_value, self.lower), self.upper)
 
-                if self.lower is not None and self.upper is not None:
-                    int_value = min(max(int_value, self.lower), self.upper)
-                    new_int_value = min(max(new_int_value, self.lower), self.upper)
-
-                if int_value != new_int_value:
-                    rejected = False
-                elif iteration > 100000:
-                    raise ValueError('Probably caught in an infinite loop.')
-
-            if transform:
-                neighbors.append(self._transform(new_value))
-            else:
-                neighbors.append(new_value)
+            neighbors.append(new_value)
         return neighbors
 
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -811,7 +811,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         else:
             raise ValueError("Illegal default value %s" % str(default_value))
 
-    def to_integer(self) -> NormalIntegerHyperparameter:
+    def to_integer(self) -> 'NormalIntegerHyperparameter':
         if self.q is None:
             q_int = None
         else:
@@ -1058,7 +1058,7 @@ cdef class BetaFloatHyperparameter(FloatHyperparameter):
     def __hash__(self):
         return hash((self.name, self.alpha, self.beta, self.log, self.q))
 
-    def to_uniform(self) -> UniformFloatHyperparameter:
+    def to_uniform(self) -> 'UniformFloatHyperparameter':
         lb = self.lower
         ub = self.upper
 
@@ -1088,7 +1088,7 @@ cdef class BetaFloatHyperparameter(FloatHyperparameter):
         else:
             raise ValueError("Illegal default value %s" % str(default_value))
 
-    def to_integer(self) -> BetaIntegerHyperparameter:
+    def to_integer(self) -> 'BetaIntegerHyperparameter':
         if self.q is None:
             q_int = None
         else:
@@ -2152,7 +2152,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
 
     # TODO review the name for this - it's just for producing a categorical hyperparameter
     # with equal weights for all choices
-    def to_uniform(self):
+    def to_uniform(self) -> 'CategoricalHyperparameter':
         return CategoricalHyperparameter(
             name=self.name,
             choices=copy.deepcopy(self.choices),

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -35,7 +35,7 @@ from collections import OrderedDict, Counter
 from typing import List, Any, Dict, Union, Set, Tuple, Optional
 
 import numpy as np
-from scipy.stats import truncnorm, beta as spbeta, norm, betabinom
+from scipy.stats import truncnorm, beta as spbeta, norm
 cimport numpy as np
 
 
@@ -262,7 +262,7 @@ cdef class Constant(Hyperparameter):
         return self._pdf(vector)
 
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
-        return np.ones(len(vector))
+        return np.ones_like(vector)
 
     def get_size(self) -> float:
         return 1.0
@@ -2716,6 +2716,6 @@ cdef class OrdinalHyperparameter(Hyperparameter):
 
     def get_max_density(self) -> float:
         return 1 / self.num_elements
-        
+
     def get_size(self) -> float:
         return len(self.sequence)

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -861,8 +861,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         return UniformFloatHyperparameter(self.name,
                                           lb,
                                           ub,
-                                          default_value=int(
-                                              np.round(self.default_value, 0)),
+                                          default_value=self.default_value,
                                           q=self.q, log=self.log)
 
     def check_default(self, default_value: Union[int, float]) -> Union[int, float]:
@@ -1942,7 +1941,7 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
             meta=self.meta
         )
 
-    def to_uniform(self, z: int = 3) -> 'UniformIntegerHyperparameter':
+    def to_uniform(self) -> 'UniformIntegerHyperparameter':
         lb = self.lower
         ub = self.upper
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -898,9 +898,6 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
 
 
-# and this one if for defining custom discrete distributions over some space 
-# with the combination of the two, you can design most reasonable probability distributions
-# TODO - implement
 cdef class BetaFloatHyperparameter(FloatHyperparameter):
     cdef public alpha
     cdef public beta
@@ -1600,7 +1597,6 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
             meta=self.meta
         )
 
-    # todo check if conversion should be done in initiation call or inside class itsel
     def to_uniform(self, z: int = 3) -> 'UniformIntegerHyperparameter':
         if self.lower is None or self.upper is None:
             lb = np.round(int(self.mu - (z * self.sigma)))
@@ -1705,9 +1701,6 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
         return self.nfhp._pdf(vector) / self.normalization_constant
 
 
-# and this one if for defining custom discrete distributions over some space 
-# with the combination of the two, you can design most reasonable probability distributions
-# TODO - implement
 cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
     cdef public alpha
     cdef public beta
@@ -1865,7 +1858,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
             meta=self.meta
         )
 
-    # todo check if conversion should be done in initiation call or inside class itsel
     def to_uniform(self, z: int = 3) -> 'UniformIntegerHyperparameter':
         lb = self.lower
         ub = self.upper
@@ -2016,7 +2008,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
         return self.bfhp._pdf(vector) / self.normalization_constant
 
 
-# TODO - implement .pdf method
 cdef class CategoricalHyperparameter(Hyperparameter):
     cdef public tuple choices
     cdef public tuple probabilities
@@ -2143,8 +2134,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             meta=self.meta
         )
 
-    # TODO review the name for this - it's just for producing a categorical hyperparameter
-    # with equal weights for all choices
+    # This is just for the uniform configspace for PiBO
+    # It creates a categorical parameter with equal weights for all choices
     def to_uniform(self) -> 'CategoricalHyperparameter':
         return CategoricalHyperparameter(
             name=self.name,
@@ -2238,8 +2229,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             return None
 
 
-    # TODO - encountered something of a bug here when this was passed through .pdf
-    # for some reason, it wanted a numpy array as output
+    # TEncountered something of a bug here when this was passed through .pdf
+    # for some reason, it wanted a numpy array as output (and as such, it is now changed)
     def _inverse_transform(self, vector: Union[None, np.ndarray, str, float, int]) -> Union[np.ndarray, int, float]:
         if vector is None:
             return np.NaN
@@ -2302,7 +2293,6 @@ cdef class CategoricalHyperparameter(Hyperparameter):
         return self._pdf(vector)
 
 
-# TODO - implement .pdf method
 cdef class OrdinalHyperparameter(Hyperparameter):
     cdef public tuple sequence
     cdef public int num_elements

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -258,16 +258,14 @@ cdef class Constant(Hyperparameter):
                       transform: bool = False) -> List:
         return []
 
-<<<<<<< HEAD
     def pdf(self, vector: np.ndarray) -> np.ndarray:
         return self._pdf(vector)
 
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         return np.ones(len(vector))
-=======
+
     def get_size(self) -> float:
         return 1.0
->>>>>>> 4d69931de5540fc6be4230731ddebf6a25d2e1a8
 
 cdef class UnParametrizedHyperparameter(Constant):
     pass
@@ -687,7 +685,6 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
                 neighbors.append(neighbor)
         return neighbors
 
-<<<<<<< HEAD
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         ub = self._upper
         lb = self._lower
@@ -697,13 +694,12 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
         ub = self._upper
         lb = self._lower
         return 1 / (ub - lb)
-=======
+        
     def get_size(self) -> float:
         if self.q is None:
             return np.inf
         else:
             return np.rint((self.upper - self.lower) / self.q) + 1
->>>>>>> 4d69931de5540fc6be4230731ddebf6a25d2e1a8
 
 
 cdef class NormalFloatHyperparameter(FloatHyperparameter):
@@ -1529,7 +1525,6 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
 
         return neighbors
 
-<<<<<<< HEAD
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         lb = self.lower
         ub = self.upper
@@ -1539,14 +1534,13 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
         lb = self.lower
         ub = self.upper
         1 / (ub - lb)
-=======
+
     def get_size(self) -> float:
         if self.q is None:
             q = 1
         else:
             q = self.q
         return np.rint((self.upper - self.lower) / q) + 1
->>>>>>> 4d69931de5540fc6be4230731ddebf6a25d2e1a8
 
 
 cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
@@ -2415,7 +2409,6 @@ cdef class CategoricalHyperparameter(Hyperparameter):
                          "OrdinalHyperparameter, but is "
                          "<cdef class 'ConfigSpace.hyperparameters.CategoricalHyperparameter'>")
 
-<<<<<<< HEAD
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         return np.array(self.probabilities[vector])
 
@@ -2425,10 +2418,9 @@ cdef class CategoricalHyperparameter(Hyperparameter):
 
     def get_max_density(self) -> float:
         return np.max(self.probabilities)
-=======
+
     def get_size(self) -> float:
         return len(self.choices)
->>>>>>> 4d69931de5540fc6be4230731ddebf6a25d2e1a8
 
 
 cdef class OrdinalHyperparameter(Hyperparameter):
@@ -2716,7 +2708,6 @@ cdef class OrdinalHyperparameter(Hyperparameter):
     def allow_greater_less_comparison(self) -> bool:
         return True
 
-<<<<<<< HEAD
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         return self.ones_like(vector) / self.num_elements
 
@@ -2725,7 +2716,6 @@ cdef class OrdinalHyperparameter(Hyperparameter):
 
     def get_max_density(self) -> float:
         return 1 / self.num_elements
-=======
+        
     def get_size(self) -> float:
         return len(self.sequence)
->>>>>>> 4d69931de5540fc6be4230731ddebf6a25d2e1a8

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -2011,14 +2011,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
         all_probabilities = self.bfhp.pdf(all_integer_values)
         return np.sum(all_probabilities)
 
-    # TODO remove
-    def get_probs(self):
-        upper = self.upper
-        lower = self.lower
-        all_integer_values = np.arange(self.lower, self.upper+1)
-        all_probabilities = self.bfhp.pdf(all_integer_values)
-        return all_integer_values, all_probabilities
-        
     def _pdf(self, vector: np.ndarray) -> np.ndarray:
         return self.bfhp._pdf(vector) / self.normalization_constant
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1997,7 +1997,6 @@ cdef class BetaIntegerHyperparameter(IntegerHyperparameter):
 
         return neighbors
 
-        
     def _compute_normalization(self):
         # to use the same pdfs, transforms etc. (and have something that generalizes)
         # across discrete parameter types, we compute the pdf for the corresponding
@@ -2148,6 +2147,16 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             choices=copy.deepcopy(self.choices),
             default_value=self.default_value,
             weights=copy.deepcopy(self.probabilities),
+            meta=self.meta
+        )
+
+    # TODO review the name for this - it's just for producing a categorical hyperparameter
+    # with equal weights for all choices
+    def to_uniform(self):
+        return CategoricalHyperparameter(
+            name=self.name,
+            choices=copy.deepcopy(self.choices),
+            default_value=self.default_value,
             meta=self.meta
         )
 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -883,14 +883,13 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         mu = self.mu
         sigma = self.sigma
         if self.lower == None:
-            return norm(loc=mu, scale=sigma).pdf(vector)
+            raise ValueError('Need upper and lower limits when using user priors.')
         else:
-            lower = self.lower
-            upper = self.upper
-            a = (lower - mu) / sigma
-            b = (upper - mu) / sigma
-            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
-
+            # regardless of whether we have log input or not, this yields the correct answer,
+            # as the data always comes in transformed
+            lower = self._lower
+            upper = self._upper
+            return truncnorm(lower, upper, loc=mu, scale=sigma).pdf(vector)
 
 
 # and this one if for defining custom discrete distributions over some space 

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -151,7 +151,7 @@ cdef class Hyperparameter(object):
     cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2):
         raise NotImplementedError()
 
-    def pdf(self, value):
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
         raise NotImplementedError()
 
 
@@ -345,7 +345,7 @@ cdef class NumericalHyperparameter(Hyperparameter):
             meta=self.meta
         )
 
-    def pdf(self, vector):
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
         raise NotImplementedError()
 
 
@@ -378,7 +378,7 @@ cdef class FloatHyperparameter(NumericalHyperparameter):
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         raise NotImplementedError()
 
-    def pdf(self, vector):
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
         vector = self._inverse_transform(vector)
         return self._pdf(vector)
 
@@ -419,7 +419,7 @@ cdef class IntegerHyperparameter(NumericalHyperparameter):
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         raise NotImplementedError()
     
-    def pdf(self, vector):
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
         vector = self._inverse_transform(vector)
         return self._pdf(vector)
 
@@ -626,7 +626,6 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
         return np.ones_like(vector) / (ub - lb)
 
 
-# TODO - implement a .pdf method here, and make sure the log case is properly considerec
 cdef class NormalFloatHyperparameter(FloatHyperparameter):
     cdef public mu
     cdef public sigma

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -16,7 +16,8 @@ from ConfigSpace.hyperparameters import (
     OrdinalHyperparameter,
     Constant,
     UnParametrizedHyperparameter,
-    BetaFloatHyperparameter
+    BetaFloatHyperparameter,
+    BetaIntegerHyperparameter
 )
 from ConfigSpace.conditions import (
     AbstractCondition,
@@ -82,7 +83,7 @@ def _build_normal_float(param: NormalFloatHyperparameter) -> Dict:
 def _build_beta_float(param: BetaFloatHyperparameter) -> Dict:
     return {
         'name': param.name,
-        'type': 'normal_float',
+        'type': 'beta_float',
         'log': param.log,
         'alpha': param.alpha,
         'beta': param.beta,
@@ -108,6 +109,17 @@ def _build_normal_int(param: NormalIntegerHyperparameter) -> Dict:
         'log': param.log,
         'mu': param.mu,
         'sigma': param.sigma,
+        'default': param.default_value
+    }
+
+
+def _build_beta_int(param: BetaIntegerHyperparameter) -> Dict:
+    return {
+        'name': param.name,
+        'type': 'beta_int',
+        'log': param.log,
+        'alpha': param.alpha,
+        'beta': param.beta,
         'default': param.default_value
     }
 
@@ -338,6 +350,8 @@ def write(configuration_space, indent=2):
             hyperparameters.append(_build_uniform_int(hyperparameter))
         elif isinstance(hyperparameter, NormalIntegerHyperparameter):
             hyperparameters.append(_build_normal_int(hyperparameter))
+        elif isinstance(hyperparameter, BetaIntegerHyperparameter):
+            hyperparameters.append(_build_beta_int(hyperparameter))
         elif isinstance(hyperparameter, CategoricalHyperparameter):
             hyperparameters.append(_build_categorical(hyperparameter))
         elif isinstance(hyperparameter, OrdinalHyperparameter):

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -16,6 +16,7 @@ from ConfigSpace.hyperparameters import (
     OrdinalHyperparameter,
     Constant,
     UnParametrizedHyperparameter,
+    BetaFloatHyperparameter
 )
 from ConfigSpace.conditions import (
     AbstractCondition,
@@ -74,6 +75,17 @@ def _build_normal_float(param: NormalFloatHyperparameter) -> Dict:
         'log': param.log,
         'mu': param.mu,
         'sigma': param.sigma,
+        'default': param.default_value
+    }
+
+
+def _build_beta_float(param: BetaFloatHyperparameter) -> Dict:
+    return {
+        'name': param.name,
+        'type': 'normal_float',
+        'log': param.log,
+        'alpha': param.alpha,
+        'beta': param.beta,
         'default': param.default_value
     }
 
@@ -320,6 +332,8 @@ def write(configuration_space, indent=2):
             hyperparameters.append(_build_uniform_float(hyperparameter))
         elif isinstance(hyperparameter, NormalFloatHyperparameter):
             hyperparameters.append(_build_normal_float(hyperparameter))
+        elif isinstance(hyperparameter, BetaFloatHyperparameter):
+            hyperparameters.append(_build_beta_float(hyperparameter))
         elif isinstance(hyperparameter, UniformIntegerHyperparameter):
             hyperparameters.append(_build_uniform_int(hyperparameter))
         elif isinstance(hyperparameter, NormalIntegerHyperparameter):

--- a/docs/source/User-Guide.rst
+++ b/docs/source/User-Guide.rst
@@ -256,7 +256,7 @@ Consider the case of optimizing the accuracy of an MLP with three hyperparameter
 >>> from ConfigSpace.configuration_space import ConfigurationSpace
 >>> # convert 10 log to natural log for learning rate, mean 1e-3
 >>> logmean = np.log(np.power(10.0, -3))
-#two standard deviations on either side of the mean to cover the search space
+>>> # two standard deviations on either side of the mean to cover the search space
 >>> logstd = np.log(10.0) 
 >>> learning_rate = CSH.NormalFloatHyperparameter(name='learning_rate', lower=1e-5, upper=1e-1, default_value=1e-3, mu=logmean, sigma=logstd, log=True)
 >>> dropout = CSH.BetaFloatHyperparameter(name='dropout', lower=0, upper=0.99, default_value=0.25, alpha=2, beta=4, log=False)

--- a/docs/source/User-Guide.rst
+++ b/docs/source/User-Guide.rst
@@ -241,3 +241,47 @@ To read it from file
     >>> with open('configspace.json', 'r') as fh:
     ...     json_string = fh.read()
     ...     restored_conf = json.read(json_string)
+
+
+
+4th Example: Placing priors on the hyperparameters
+-------------------------
+
+If you want to conduct black-box optimization in SMAC, and you have prior knowledge about the which regions of the search space are more likely to contain the optimum, you may include this knowledge when designing the configuration space. More specifically, you place prior distributions over the optimum on the parameters, either by a (log)-normal or (log)-Beta distribution.
+
+Consider the case of optimizing the accuracy of an MLP with three hyperparameters: learning rate [1e-5, 1e-1], dropout [0, 0.99] and activation {Tanh, ReLU}. From prior experience, you believe the optimal learning rate to be around 1e-3, a good dropout to be around 0.25, and the optimal activation function to be ReLU about 80% of the time. This can be represented accordingly:
+
+>>> import numpy as np
+>>> import ConfigSpace.hyperparameters as CSH
+>>> from ConfigSpace.configuration_space import ConfigurationSpace
+
+>>> # convert 10 log to natural log for learning rate, mean 1e-3
+>>> logmean = np.log(np.power(10.0, -3))
+#two standard deviations on either side of the mean to cover the search space
+>>> logstd = np.log(10.0) 
+
+>>> learning_rate = CSH.NormalFloatHyperparameter(name='learning_rate', lower=1e-5, upper=1e-1, default_value=1e-3, mu=logmean, sigma=logstd, log=True)
+>>> dropout = CSH.BetaFloatHyperparameter(name='dropout', lower=0, upper=0.99, default_value=0.25, alpha=2, beta=4, log=False)
+>>> activation = CSH.CategoricalHyperparameter(name='activation', choices=['tanh', 'relu'], weights=[0.2, 0.8])
+
+>>> cs = ConfigurationSpace()
+>>> cs.add_hyperparameters([learning_rate, dropout, activation])
+
+Configuration space object:
+  Hyperparameters:
+    activation, Type: Categorical, Choices: {tanh, relu}, Default: tanh, Probabilities: (0.2, 0.8)
+    dropout, Type: BetaFloat, Alpha: 2.0 Beta: 4.0, Range: [0.0, 0.99], Default: 0.25
+    learning_rate, Type: NormalFloat, Mu: -6.907755278982137 Sigma: 2.302585092994046, Range: [1e-05, 0.1], Default: 0.001, on log-scale
+
+To check that your prior makes sense for each hyperparameter, you can easily do so with the __pdf__ method:
+
+>>> test_points = np.logspace(-5, -1, 5) 
+>>> test_points
+[1.e-05 1.e-04 1.e-03 1.e-02 1.e-01]                    
+
+>>> learning_rate.pdf(test_points)
+[0.02456573 0.11009594 0.18151753 0.11009594 0.02456573]
+
+
+
+

--- a/docs/source/User-Guide.rst
+++ b/docs/source/User-Guide.rst
@@ -254,19 +254,16 @@ Consider the case of optimizing the accuracy of an MLP with three hyperparameter
 >>> import numpy as np
 >>> import ConfigSpace.hyperparameters as CSH
 >>> from ConfigSpace.configuration_space import ConfigurationSpace
-
 >>> # convert 10 log to natural log for learning rate, mean 1e-3
 >>> logmean = np.log(np.power(10.0, -3))
 #two standard deviations on either side of the mean to cover the search space
 >>> logstd = np.log(10.0) 
-
 >>> learning_rate = CSH.NormalFloatHyperparameter(name='learning_rate', lower=1e-5, upper=1e-1, default_value=1e-3, mu=logmean, sigma=logstd, log=True)
 >>> dropout = CSH.BetaFloatHyperparameter(name='dropout', lower=0, upper=0.99, default_value=0.25, alpha=2, beta=4, log=False)
 >>> activation = CSH.CategoricalHyperparameter(name='activation', choices=['tanh', 'relu'], weights=[0.2, 0.8])
 
 >>> cs = ConfigurationSpace()
 >>> cs.add_hyperparameters([learning_rate, dropout, activation])
-
 Configuration space object:
   Hyperparameters:
     activation, Type: Categorical, Choices: {tanh, relu}, Default: tanh, Probabilities: (0.2, 0.8)
@@ -278,7 +275,6 @@ To check that your prior makes sense for each hyperparameter, you can easily do 
 >>> test_points = np.logspace(-5, -1, 5) 
 >>> test_points
 [1.e-05 1.e-04 1.e-03 1.e-02 1.e-01]                    
-
 >>> learning_rate.pdf(test_points)
 [0.02456573 0.11009594 0.18151753 0.11009594 0.02456573]
 

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -357,6 +357,16 @@ class TestHyperparameters(unittest.TestCase):
         )
         self.assertEqual(f1.get_neighbors(0.5, rs=np.random.RandomState(42)),
                          [0.8973713224089861, 0.38938855906305225, 1.018150830480554, 1.7184238851264204])
+        
+        b1_ext = BetaFloatHyperparameter("param", lower=-12.0, upper=12.0, alpha=3.0, beta=1.0)
+        self.assertEqual(b1_ext.get_neighbors(11.99, rs=np.random.RandomState(42)),
+                         [11.326331354378313, 10.866063801327988, 10.866142606643933, 9.73652294751223])
+
+        b1_log = BetaFloatHyperparameter("param", lower=1.0, upper=1000.0, alpha=3.0, beta=1.0, log=True)
+        self.assertEqual(b1_log.get_neighbors(np.log(1000), rs=np.random.RandomState(42), transform=True),
+                         [826.1167337763767, 723.6156902737724, 723.6321035060932, 522.7756713749886])
+        self.assertEqual(b1_log.get_neighbors(np.log(1), rs=np.random.RandomState(42), transform=True),
+                         [1.986225219010177, 2.4468825448117744, 8.200076685608781, 8.861917227659887])
 
         # Test attributes are accessible
         self.assertEqual(f1.name, "param")
@@ -408,11 +418,12 @@ class TestHyperparameters(unittest.TestCase):
         f5_illegal_log = BetaFloatHyperparameter("param", lower=1, upper=1000.0, alpha=3.0, beta=2.0, default_value=0, log=True)
         f5_legal_nolog = BetaFloatHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, default_value=1, log=True)
         f5_legal_log = BetaFloatHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, default_value=1, log=False)
+        f5_q = BetaFloatHyperparameter("param", lower=1, upper=1000.0, alpha=2.0, beta=3.0, q=3.0)
+        
         self.assertAlmostEqual(f5_illegal_nolog.default_value, 7)
         self.assertAlmostEqual(f5_illegal_log.default_value, 100)
         self.assertAlmostEqual(f5_legal_nolog.default_value, 1)
         self.assertAlmostEqual(f5_legal_log.default_value, 1)
-
         
         # test that meta-data is stored correctly
         f_meta = BetaFloatHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, log=False, meta=dict(self.meta_data))
@@ -688,6 +699,139 @@ class TestHyperparameters(unittest.TestCase):
         self.assertTrue(f1.is_legal(2))
         self.assertTrue(f1.is_legal(-15))
 
+        # Test is legal vector
+        self.assertTrue(f1.is_legal_vector(1.0))
+        self.assertTrue(f1.is_legal_vector(0.0))
+        self.assertTrue(f1.is_legal_vector(0))
+        self.assertTrue(f1.is_legal_vector(0.3))
+        self.assertTrue(f1.is_legal_vector(-0.1))
+        self.assertTrue(f1.is_legal_vector(1.1))
+        self.assertRaises(TypeError, f1.is_legal_vector, "Hahaha")
+
+    ############################################################
+    def test_betaint(self):
+ # TODO test non-equality
+        f1 = BetaIntegerHyperparameter("param", lower=-2.0, upper=2.0, alpha=3.0, beta=1.1)
+        f1_ = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=3, beta=1.1)
+        self.assertEqual(f1, f1_)
+        self.assertEqual(
+            "param, Type: BetaInteger, Alpha: 3.0 Beta: 1.1, Range: [-2, 2], Default: 2",
+            str(f1))
+
+        # test parameters that do not create a legit beta distribution    
+        with self.assertRaises(ValueError):
+            f1_error_a = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=5, beta=-11)
+            f1_error_b = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=-11, beta=5)
+        
+        # test parameters that do not yield a finite co-domain
+        with self.assertRaises(ValueError):
+            f1_error_a = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=0.5, beta=11)
+            f1_error_b = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=11, beta=0.5)
+          
+        with pytest.warns(UserWarning, match="Setting quantization < 1 for Integer "
+                                        "Hyperparameter 'param' has no effect"):
+            f2 = BetaIntegerHyperparameter("param", lower=-2, upper=2, alpha=5, beta=11, q=0.1)
+
+        b1 = BetaIntegerHyperparameter("param", lower=-3, upper=10, alpha=3.0, beta=1.0)
+        self.assertEqual(b1.get_neighbors(2, rs=np.random.RandomState(42)),
+                         [3.0, 4.0, 6.0, 1.0])
+        
+        b1_ext = BetaIntegerHyperparameter("param", lower=-12.0, upper=12.0, alpha=3.0, beta=1.0)
+        self.assertEqual(b1_ext.get_neighbors(12, rs=np.random.RandomState(42)),
+                         [11.0, 10.0, 3.0, 4.0])
+
+        b1_log = BetaIntegerHyperparameter("param", lower=1.0, upper=1000.0, alpha=3.0, beta=1.0, log=True)
+        self.assertEqual(b1_log.get_neighbors(np.log(1000), rs=np.random.RandomState(42), transform=True),
+                         [826, 724, 523, 527])
+        self.assertEqual(b1_log.get_neighbors(np.log(1), rs=np.random.RandomState(42), transform=True),
+                         [2, 8, 9, 3])
+        
+        # Test attributes are accessible
+        self.assertEqual(f1.name, "param")
+        self.assertAlmostEqual(f1.alpha, 3.0)
+        self.assertAlmostEqual(f1.beta, 1.1) 
+        self.assertAlmostEqual(f1.q, None)
+        self.assertEqual(f1.log, False)
+        self.assertEqual(f1.default_value, 2)
+        # beta parameters are not normalized (as normal parameters are not, either. Not sure if that's best.)
+        self.assertEqual(f1.normalized_default_value, 2)
+        
+        # Test copy
+        copy_f1 = copy.copy(f1)
+
+        self.assertEqual(copy_f1.name, f1.name)
+        self.assertEqual(copy_f1.alpha, f1.alpha)
+        self.assertEqual(copy_f1.beta, f1.beta)
+        self.assertEqual(copy_f1.default_value, f1.default_value)
+
+        
+        f2 = BetaIntegerHyperparameter("param", lower=-2.0, upper=4.0, alpha=3.0, beta=1.1, q=2)
+        f2_ = BetaIntegerHyperparameter("param", lower=-2, upper=4, alpha=3, beta=1.1, q=2)
+        self.assertEqual(f2, f2_)
+ 
+        self.assertEqual(
+            "param, Type: BetaInteger, Alpha: 3.0 Beta: 1.1, Range: [-2, 4], Default: 4, "
+            "Q: 2", str(f2))
+        
+        f3 = BetaIntegerHyperparameter("param", lower=1, upper=1000, alpha=3.0, beta=2.0, log=True)
+        f3_ = BetaIntegerHyperparameter("param", lower=1, upper=1000, alpha=3.0, beta=2.0, log=True)
+        self.assertEqual(f3, f3_)
+        self.assertEqual(
+            "param, Type: BetaInteger, Alpha: 3.0 Beta: 2.0, Range: [1, 1000], Default: 100, "
+            "on log-scale", str(f3))
+
+        with self.assertRaises(ValueError):
+            f3_error = BetaIntegerHyperparameter("param", lower=-1, upper=10.0, alpha=6.0, beta=2.0, log=True)
+        
+        f4_illegal_nolog = BetaIntegerHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, default_value=0, log=False)
+        f4_illegal_log = BetaIntegerHyperparameter("param", lower=1, upper=1000.0, alpha=3.0, beta=2.0, default_value=0, log=True)
+        f4_legal_nolog = BetaIntegerHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, default_value=1, log=True)
+        f4_legal_log = BetaIntegerHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, default_value=1, log=False)
+        self.assertAlmostEqual(f4_illegal_nolog.default_value, 7)
+        self.assertAlmostEqual(f4_illegal_log.default_value, 100)
+        self.assertAlmostEqual(f4_legal_nolog.default_value, 1)
+        self.assertAlmostEqual(f4_legal_log.default_value, 1)
+  
+        # test that meta-data is stored correctly
+        f_meta = BetaFloatHyperparameter("param", lower=1, upper=10.0, alpha=3.0, beta=2.0, log=False, meta=dict(self.meta_data))
+        self.assertEqual(f_meta.meta, self.meta_data)
+        
+        self.assertEqual(f1.get_size(), 5)
+        self.assertEqual(f2.get_size(), 4)
+        self.assertEqual(f3.get_size(), 1000)
+
+    def test_betaint_legal_float_values(self):
+        f1 = BetaIntegerHyperparameter("param", lower=-2.0, upper=2.0, alpha=3.0, beta=1.1)
+        self.assertIsInstance(f1.default_value, int)
+        self.assertRaisesRegex(ValueError, r"For the Integer parameter param, "
+                                           r"the value must be an Integer, too."
+                                           r" Right now it is a "
+                                           r"<(type|class) 'float'>"
+                                           r" with value 0.5.",
+                               BetaIntegerHyperparameter, "param", lower=-2.0, upper=2.0, alpha=3.0, beta=1.1, default_value=0.5)
+
+    def test_betaint_to_uniform(self):
+        with pytest.warns(UserWarning, match="Setting quantization < 1 for Integer "
+                                             "Hyperparameter 'param' has no effect"):
+            f1 = BetaIntegerHyperparameter("param", lower=-30, upper=30, alpha=6.0, beta=2, q=0.1)
+
+        # right or wrong, a default is inferred in the beta parameter (as the mode of the pdf) and carried on to uniform
+        f1_expected = UniformIntegerHyperparameter("param", -30, 30, default_value=20)
+        f1_actual = f1.to_uniform()
+        self.assertEqual(f1_expected, f1_actual)
+
+    def test_betaint_is_legal(self):
+        with self.assertRaises(ValueError):
+            f1 = BetaIntegerHyperparameter("param", lower=0, upper=30, alpha=6.0, beta=2, log=True)
+
+        f1 = BetaIntegerHyperparameter("param", lower=-5, upper=30, alpha=6.0, beta=2)
+        self.assertFalse(f1.is_legal(3.1))
+        self.assertFalse(f1.is_legal(3.0))   # 3.0 behaves like an Integer
+        self.assertFalse(f1.is_legal("BlaBlaBla"))
+        self.assertTrue(f1.is_legal(2))
+        self.assertTrue(f1.is_legal(-5))
+        self.assertFalse(f1.is_legal(-15))
+        
         # Test is legal vector
         self.assertTrue(f1.is_legal_vector(1.0))
         self.assertTrue(f1.is_legal_vector(0.0))

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -168,7 +168,10 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(c1._pdf(accepted_shape_3)[2][0], 1.0)
         
     def test_constant_get_max_density(self):
-        pass
+        c1 = Constant("valuee", 1)
+        c2 = Constant("valueee", -2)
+        self.assertEqual(c1.get_max_density(), 1.0)
+        self.assertEqual(c2.get_max_density(), 1.0)
 
     def test_uniformfloat(self):
         # TODO test non-equality
@@ -386,7 +389,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(c1._pdf(accepted_shape_3)[2][0], 0.1)
 
     def test_uniformfloat_get_max_density(self):
-        pass
+        c1 = UniformFloatHyperparameter("param", lower=0, upper=10)
+        c2 = UniformFloatHyperparameter("logparam", lower=np.exp(0), upper=np.exp(10), log=True)
+        c3 = UniformFloatHyperparameter("param", lower=0, upper=0.5)
+        self.assertEqual(c1.get_max_density(), 0.1)
+        self.assertAlmostEqual(c2.get_max_density(), 4.539992976248485e-05)
+        self.assertEqual(c3.get_max_density(), 2)
 
     def test_normalfloat(self):
         # TODO test non-equality
@@ -635,7 +643,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.2138045617479014)
 
     def test_normalfloat_get_max_density(self):
-        pass
+        c1 = NormalFloatHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)
+        c2 = NormalFloatHyperparameter("logparam", lower=np.exp(0), upper=np.exp(10), mu=3, sigma=2, log=True)
+        c3 = NormalFloatHyperparameter("param", lower=0, upper=0.5, mu=-1, sigma=0.2)
+        self.assertEqual(c1.get_max_density(), 0.2138045617479014)
+        self.assertAlmostEqual(c2.get_max_density(), 0.2138045617479014)
+        self.assertEqual(c3.get_max_density(), 25.932522722334905)
 
     def test_betafloat(self):
         # TODO test non-equality
@@ -740,23 +753,7 @@ class TestHyperparameters(unittest.TestCase):
         for float_hp in (f1, f3):
             self.assertTrue(np.isinf(float_hp.get_size()))
         self.assertEqual(f4.get_size(), 1000)
-    
-    def test_sample_betafloat(self):
-        rs = np.random.RandomState(1)
-        f1 = BetaFloatHyperparameter("param", lower=-2.0, upper=2.0, alpha=1.2, beta=1.1)
-        f1_log = BetaFloatHyperparameter("param", lower=1, upper=1000, alpha=1.2, beta=1.1, log=True)
-        samples = f1._sample(rs=rs, size=10000)
-        samples_log = f1_log._sample(rs=rs, size=10000)
-        self.assertTrue(np.all(samples > f1._lower))
-        self.assertTrue(np.all(samples < f1._upper))
-        self.assertTrue(np.all(samples_log > f1_log._lower))
-        self.assertTrue(np.all(samples_log < f1_log._upper))
-    
-        for i in range(100):  
-            self.assertTrue((f1.sample(rs) > f1.lower) and (f1.sample(rs) < f1.upper))
-            self.assertTrue((f1_log.sample(rs) > f1_log.lower) and (f1_log.sample(rs) < f1_log.upper))
-
-    
+        
     def test_betafloat_to_uniformfloat(self):
         f1 = BetaFloatHyperparameter("param", lower=-2.0, upper=2.0, alpha=4, beta=2, q=0.1)
         f1_expected = UniformFloatHyperparameter("param", lower=-2.0, upper=2.0, q=0.1, default_value=1)
@@ -911,7 +908,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.07559999999999997)
 
     def test_betafloat_get_max_density(self):
-        pass
+        c1 = BetaFloatHyperparameter("param", lower=0, upper=10, alpha=3, beta=2)
+        c2 = BetaFloatHyperparameter("logparam", lower=np.exp(0), upper=np.exp(10), alpha=3, beta=2, log=True)
+        c3 = BetaFloatHyperparameter("param", lower=0, upper=0.5, alpha=1.1, beta=25)
+        self.assertAlmostEqual(c1.get_max_density(), 0.17777777777777776)
+        self.assertAlmostEqual(c2.get_max_density(), 0.17777777777777776)
+        self.assertAlmostEqual(c3.get_max_density(), 38.00408137865127)
 
     def test_uniforminteger(self):
         # TODO: rounding or converting or error message?
@@ -1118,7 +1120,13 @@ class TestHyperparameters(unittest.TestCase):
         self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.2, places=5)
 
     def test_uniformint_get_max_density(self):
-        pass
+        c1 = UniformIntegerHyperparameter("param", lower=0, upper=4)
+        c2 = UniformIntegerHyperparameter("logparam", lower=1, upper=10000, log=True)
+        c3 = UniformIntegerHyperparameter("param", lower=-1, upper=12)
+        self.assertAlmostEqual(c1.get_max_density(), 0.2)
+        self.assertAlmostEqual(c2.get_max_density(), 0.0001)
+        self.assertAlmostEqual(c3.get_max_density(), 0.07142857142857142)
+        
 
     def test_normalint(self):
         # TODO test for unequal!
@@ -1339,7 +1347,12 @@ class TestHyperparameters(unittest.TestCase):
             c_error.pdf(np.array([0.2]))
 
     def test_normalint_get_max_density(self):
-        pass
+        c1 = NormalIntegerHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)
+        c2 = NormalIntegerHyperparameter("logparam", lower=1, upper=1000, mu=3, sigma=2, log=True)
+        c3 = NormalIntegerHyperparameter("param", lower=0, upper=2, mu=-1.2, sigma=0.5)
+        self.assertAlmostEqual(c1.get_max_density(), 0.20747194595587332)
+        self.assertAlmostEqual(c2.get_max_density(), 0.002790371598208875)
+        self.assertAlmostEqual(c3.get_max_density(), 0.9988874412972069)
 
     ############################################################
     def test_betaint(self):
@@ -1582,7 +1595,13 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf(wrong_shape_3)
 
     def test_betaint_get_max_density(self):
-        pass
+        c1 = BetaIntegerHyperparameter("param", alpha=3, beta=2, lower=0, upper=10)
+        c2 = BetaIntegerHyperparameter("logparam", alpha=3, beta=2, lower=1, upper=1000, log=True)
+        c3 = BetaIntegerHyperparameter("param", alpha=1.1, beta=10, lower=0, upper=3)
+        self.assertAlmostEqual(c1.get_max_density(), 0.1781818181818181)
+        self.assertAlmostEqual(c2.get_max_density(), 0.0018733953504422762)
+        self.assertAlmostEqual(c3.get_max_density(), 0.9979110652388783)
+        
 
     def test_categorical(self):
         # TODO test for inequality
@@ -1753,7 +1772,7 @@ class TestHyperparameters(unittest.TestCase):
         wrong_shape_1 = np.array([["one"]])
         wrong_shape_2 = np.array(["one", "two"]).reshape(1, -1)
         wrong_shape_3 = np.array(["one", "two"]).reshape(-1, 1)
-        
+
         self.assertEqual(c1.pdf(point_1)[0], 0.4)
         self.assertEqual(c1.pdf(point_2)[0], 0.2)
         self.assertAlmostEqual(c2.pdf(point_1)[0], 0.7142857142857143)
@@ -1808,9 +1827,13 @@ class TestHyperparameters(unittest.TestCase):
         with self.assertRaises(IndexError):
             c1._pdf(np.array(['zero']))
         
-
     def test_categorical_get_max_density(self):
-        pass
+        c1 = CategoricalHyperparameter('x1', choices=['one', 'two', 'three'], weights=[2, 1, 2])
+        c2 = CategoricalHyperparameter('x1', choices=['one', 'two', 'three'], weights=[5, 0, 2])
+        c3 = CategoricalHyperparameter('x1', choices=['one', 'two', 'three'])
+        self.assertEqual(c1.get_max_density(), 0.4)
+        self.assertEqual(c2.get_max_density(), 0.7142857142857143)
+        self.assertAlmostEqual(c3.get_max_density(), 0.33333333333333)
 
     def test_sample_NormalFloatHyperparameter(self):
         hp = NormalFloatHyperparameter("nfhp", 0, 1)
@@ -1851,10 +1874,19 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(actual_test(), actual_test())
 
     def test_sample_BetaFloatHyperparameter(self):
-        pass
+        rs = np.random.RandomState(1)
+        f1 = BetaFloatHyperparameter("param", lower=-2.0, upper=2.0, alpha=1.2, beta=1.1)
+        f1_log = BetaFloatHyperparameter("param", lower=1, upper=1000, alpha=1.2, beta=1.1, log=True)
+        samples = f1._sample(rs=rs, size=10000)
+        samples_log = f1_log._sample(rs=rs, size=10000)
+        self.assertTrue(np.all(samples > f1._lower))
+        self.assertTrue(np.all(samples < f1._upper))
+        self.assertTrue(np.all(samples_log > f1_log._lower))
+        self.assertTrue(np.all(samples_log < f1_log._upper))
     
-    def test_sample_BetaFloatHyperparameter(self):
-        pass
+        for i in range(100):  
+            self.assertTrue((f1.sample(rs) > f1.lower) and (f1.sample(rs) < f1.upper))
+            self.assertTrue((f1_log.sample(rs) > f1_log.lower) and (f1_log.sample(rs) < f1_log.upper))
 
     def test_sample_UniformIntegerHyperparameter(self):
         # TODO: disentangle, actually test _sample and test sample on the
@@ -2039,9 +2071,6 @@ class TestHyperparameters(unittest.TestCase):
             values.append(hp._sample(rs))
         self.assertEqual(len(np.unique(values)), 5)
 
-    def test_sample_BetaIntegerHyperparameter(self):
-        pass
-    
     def test_sample_BetaIntegerHyperparameter(self):
         pass
 
@@ -2385,6 +2414,12 @@ class TestHyperparameters(unittest.TestCase):
             c1._pdf('one')
         with self.assertRaises(IndexError):
             c1._pdf(np.array(['zero']))
+
+    def test_ordinal_get_max_density(self):
+        c1 = OrdinalHyperparameter("temp", ["freezing", "cold", "warm", "hot"])
+        c2 = OrdinalHyperparameter("temp", ["freezing", "cold"])
+        self.assertEqual(c1.get_max_density(), 0.25)
+        self.assertEqual(c2.get_max_density(), 0.5)
 
     def test_rvs(self):
         f1 = UniformFloatHyperparameter("param", 0, 10)

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1475,7 +1475,111 @@ class TestHyperparameters(unittest.TestCase):
         self.assertRaises(TypeError, f1.is_legal_vector, "Hahaha")
 
     def test_betaint_pdf(self):
-        pass
+        c1 = BetaIntegerHyperparameter("param", alpha=3, beta=2, lower=0, upper=10)
+        c2 = BetaIntegerHyperparameter("logparam", alpha=3, beta=2, lower=1, upper=1000, log=True)
+        c3 = BetaIntegerHyperparameter("param", alpha=1.1, beta=10, lower=0, upper=3)
+        
+        point_1 = np.array([3])
+        point_1_log = np.array([9])
+        point_2 = np.array([9])
+        point_2_log = np.array([570])
+        point_3 = np.array([1])
+        array_1 = np.array([3, 9, 11])
+        array_1_log = np.array([9, 570, 1001])
+        point_outside_range_1 = np.array([-1])
+        point_outside_range_2 = np.array([11])
+        point_outside_range_1_log = np.array([0])
+        point_outside_range_2_log = np.array([1001])
+        non_integer_point = np.array([5.7])
+        wrong_shape_1 = np.array([[3]])
+        wrong_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
+        wrong_shape_3 = np.array([3, 5, 7]).reshape(-1, 1)
+        
+        self.assertAlmostEqual(c1.pdf(point_1)[0], 0.07636363636363634)
+        self.assertAlmostEqual(c2.pdf(point_1_log)[0], 0.0008724511426701984)
+        self.assertAlmostEqual(c1.pdf(point_2)[0], 0.09818181818181816)
+        self.assertAlmostEqual(c2.pdf(point_2_log)[0], 0.0008683622684160343)
+        self.assertAlmostEqual(c3.pdf(point_3)[0], 0.9979110652388783)        
+        
+        self.assertEqual(c1.pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c1.pdf(point_outside_range_2)[0], 0.0)
+        self.assertEqual(c2.pdf(point_outside_range_1_log)[0], 0.0)
+        self.assertEqual(c2.pdf(point_outside_range_2_log)[0], 0.0)
+
+        self.assertEqual(c1.pdf(non_integer_point)[0], 0.0)
+        self.assertEqual(c2.pdf(non_integer_point)[0], 0.0)
+        
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1_log)
+        expected_results = np.array([0.07636363636363634, 0.09818181818181816, 0])
+        expected_results_log = np.array([0.0008724511426701984, 0.0008683622684160343, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results_log, expected_results, expected_results_log):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_log_res)
+        
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1.pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1.pdf('pdf')
+   
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_1)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_2)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_3)
+    
+    def test_betaint__pdf(self):
+        c1 = BetaIntegerHyperparameter("param", alpha=3, beta=2, lower=0, upper=10)
+        c2 = BetaIntegerHyperparameter("logparam", alpha=3, beta=2, lower=1, upper=1000, log=True)
+        c3 = BetaIntegerHyperparameter("param", alpha=1.1, beta=10, lower=0, upper=3)
+        
+        point_1 = np.array([3])
+        point_2 = np.array([5.7])
+        point_3 = np.array([1])
+        array_1 = np.array([3, 5.7, 11])
+        point_outside_range_1 = np.array([-1])
+        point_outside_range_2 = np.array([11])
+        wrong_shape_1 = np.array([[3]])
+        wrong_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
+        wrong_shape_3 = np.array([3, 5, 7]).reshape(-1, 1)
+        
+        self.assertAlmostEqual(c1._pdf(point_1)[0], 0.07636363636363634)
+        self.assertAlmostEqual(c2._pdf(point_1)[0], 0.001349249446209734)
+        self.assertAlmostEqual(c1._pdf(point_2)[0], 0.16934181818181823)
+        self.assertAlmostEqual(c2._pdf(point_2)[0], 0.0015053969658279712)
+        self.assertAlmostEqual(c3._pdf(point_3)[0], 0.9979110652388783)        
+        
+        self.assertEqual(c1._pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c1._pdf(point_outside_range_2)[0], 0.0)
+        self.assertEqual(c2._pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c2._pdf(point_outside_range_2)[0], 0.0)
+        
+        array_results = c1._pdf(array_1)
+        array_results_log = c2._pdf(array_1)
+        expected_results = np.array([0.07636363636363634, 0.16934181818181823, 0])
+        expected_results_log = np.array([0.001349249446209734, 0.0015053969658279712, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results_log, expected_results, expected_results_log):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_log_res)
+        
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1.pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1.pdf('pdf')
+   
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_1)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_2)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_3)
 
     def test_betaint_get_max_density(self):
         pass

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -537,9 +537,15 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(c2.pdf(point_outside_range_1_log)[0], 0.0)
         self.assertEqual(c2.pdf(point_outside_range_2_log)[0], 0.0)
         
-        self.assertEqual(tuple(c1.pdf(array_1)), tuple(np.array([0.2138045617479014, 0.0004676955798505186, 0])))
-        self.assertEqual(tuple(c2.pdf(array_1_log)), tuple(np.array([0.2138045617479014, 0.0004676955798505186, 0])))
-
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1_log)
+        expected_results = np.array([0.2138045617479014, 0.0004676955798505186, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res in zip(array_results, array_results, expected_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_res)
+        
         # pdf must take a numpy array
         with self.assertRaises(TypeError):
             c1.pdf(0.2)
@@ -587,8 +593,14 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(c2._pdf(point_outside_range_1)[0], 0.0)
         self.assertEqual(c2._pdf(point_outside_range_2)[0], 0.0)
         
-        self.assertEqual(tuple(c1._pdf(array_1)), tuple(np.array([0.2138045617479014, 0.0004676955798505186, 0])))
-        self.assertEqual(tuple(c2._pdf(array_1)), tuple(np.array([0.2138045617479014, 0.0004676955798505186, 0])))
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1)
+        expected_results = np.array([0.2138045617479014, 0.0004676955798505186, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res in zip(array_results, array_results, expected_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_res)
 
         # pdf must take a numpy array
         with self.assertRaises(TypeError):
@@ -601,11 +613,11 @@ class TestHyperparameters(unittest.TestCase):
             c_error._pdf(np.array([2]))
 
         # Simply check that it runs, since _pdf does not restrict shape (only public method does)
-        self.assertEqual(c1._pdf(accepted_shape_1)[0][0], 0.2138045617479014)
-        self.assertEqual(c1._pdf(accepted_shape_2)[0][0], 0.2138045617479014)
-        self.assertEqual(c1._pdf(accepted_shape_2)[0][2], 0.028935300921432087)
-        self.assertEqual(c1._pdf(accepted_shape_3)[0][0], 0.028935300921432087)
-        self.assertEqual(c1._pdf(accepted_shape_3)[2][0], 0.2138045617479014)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_1)[0][0], 0.2138045617479014)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][0], 0.2138045617479014)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][2], 0.028935300921432087)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[0][0], 0.028935300921432087)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.2138045617479014)
 
     def test_normalfloat_get_max_density(self):
         pass
@@ -780,7 +792,108 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(f2_expected, f2_actual)
 
     def test_betafloat_pdf(self):
-        pass
+        c1 = BetaFloatHyperparameter("param", lower=0, upper=10, alpha=3, beta=2)
+        c2 = BetaFloatHyperparameter("logparam", lower=np.exp(0), upper=np.exp(10), alpha=3, beta=2, log=True)
+        c3 = BetaFloatHyperparameter("param", lower=0, upper=0.5, alpha=1.1, beta=25)
+        
+        point_1 = np.array([3])
+        point_1_log = np.array([np.exp(3)])
+        point_2 = np.array([9.9])
+        point_2_log = np.array([np.exp(9.9)])
+        point_3 = np.array([0.01])
+        array_1 = np.array([3, 9.9, 10.01])
+        array_1_log = np.array([np.exp(3), np.exp(9.9), np.exp(10.01)])
+        point_outside_range_1 = np.array([-0.01])
+        point_outside_range_2 = np.array([10.01])
+        point_outside_range_1_log = np.array([np.exp(-0.01)])
+        point_outside_range_2_log = np.array([np.exp(10.01)])
+        wrong_shape_1 = np.array([[3]])
+        wrong_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
+        wrong_shape_3 = np.array([3, 5, 7]).reshape(-1, 1)
+        
+        self.assertAlmostEqual(c1.pdf(point_1)[0], 0.07559999999999997)
+        self.assertAlmostEqual(c2.pdf(point_1_log)[0], 0.07559999999999997)
+        self.assertAlmostEqual(c1.pdf(point_2)[0], 0.011761200000000013)
+        self.assertAlmostEqual(c2.pdf(point_2_log)[0], 0.011761200000000013)
+        self.assertAlmostEqual(c3.pdf(point_3)[0], 30.262164001861198)        
+        # TODO - change this once the is_legal support is there
+        # but does not have an actual impact of now
+        self.assertEqual(c1.pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c1.pdf(point_outside_range_2)[0], 0.0)
+        self.assertEqual(c2.pdf(point_outside_range_1_log)[0], 0.0)
+        self.assertEqual(c2.pdf(point_outside_range_2_log)[0], 0.0)
+        
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1_log)
+        expected_results = np.array([0.07559999999999997, 0.011761200000000013, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res in zip(array_results, array_results, expected_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_res)
+        
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1.pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1.pdf('pdf')
+   
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_1)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_2)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_3)
+
+    def test_betafloat__pdf(self):
+        c1 = BetaFloatHyperparameter("param", lower=0, upper=10, alpha=3, beta=2)
+        c2 = BetaFloatHyperparameter("logparam", lower=np.exp(0), upper=np.exp(10), alpha=3, beta=2, log=True)
+        c3 = BetaFloatHyperparameter("param", lower=0, upper=0.5, alpha=1.1, beta=25)
+        
+        point_1 = np.array([3])
+        point_2 = np.array([9.9])
+        point_3 = np.array([0.01])
+        array_1 = np.array([3, 9.9, 10.01])
+        point_outside_range_1 = np.array([-0.01])
+        point_outside_range_2 = np.array([10.01])
+        accepted_shape_1 = np.array([[3]])
+        accepted_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
+        accepted_shape_3 = np.array([7, 5, 3]).reshape(-1, 1)
+        
+        self.assertAlmostEqual(c1._pdf(point_1)[0], 0.07559999999999997)
+        self.assertAlmostEqual(c2._pdf(point_1)[0], 0.07559999999999997)
+        self.assertAlmostEqual(c1._pdf(point_2)[0], 0.011761200000000013)
+        self.assertAlmostEqual(c2._pdf(point_2)[0], 0.011761200000000013)
+        self.assertAlmostEqual(c3._pdf(point_3)[0], 30.262164001861198)        
+        
+        # TODO - change this once the is_legal support is there
+        # but does not have an actual impact of now
+        self.assertEqual(c1._pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c1._pdf(point_outside_range_2)[0], 0.0)
+        self.assertEqual(c2._pdf(point_outside_range_1)[0], 0.0)
+        self.assertEqual(c2._pdf(point_outside_range_2)[0], 0.0)
+        
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1)
+        expected_results = np.array([0.07559999999999997, 0.011761200000000013, 0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res in zip(array_results, array_results, expected_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_res)
+        
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1.pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1.pdf('pdf')
+   
+        # Simply check that it runs, since _pdf does not restrict shape (only public method does)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_1)[0][0], 0.07559999999999997)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][0], 0.07559999999999997)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][2], 0.1764)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[0][0], 0.1764)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.07559999999999997)
 
     def test_betafloat_get_max_density(self):
         pass

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -88,6 +88,12 @@ class TestHyperparameters(unittest.TestCase):
         for constant in (c1, c2, c3, c4, c5, c1_meta):
             self.assertEqual(constant.get_size(), 1)
 
+    def test_constant_pdf(self):
+        pass
+
+    def test_constant_get_max_density(self):
+        pass
+
     def test_uniformfloat(self):
         # TODO test non-equality
         # TODO test sampling from a log-distribution which has a negative
@@ -196,6 +202,12 @@ class TestHyperparameters(unittest.TestCase):
             ValueError, "Upper bound 0.000000 must be larger than lower bound "
             "1.000000 for hyperparameter param", UniformFloatHyperparameter,
             "param", 1, 0)
+
+    def test_uniformfloat_pdf(self):
+        pass
+
+    def test_uniformfloat_get_max_density(self):
+        pass
 
     def test_normalfloat(self):
         # TODO test non-equality
@@ -328,6 +340,12 @@ class TestHyperparameters(unittest.TestCase):
         f2_expected = NormalIntegerHyperparameter("param", 0, 10)
         f2_actual = f1.to_integer()
         self.assertEqual(f2_expected, f2_actual)
+
+    def test_normalfloat_pdf(self):
+        pass
+
+    def test_normalfloat_get_max_density(self):
+        pass
 
     def test_betafloat(self):
         # TODO test non-equality
@@ -498,6 +516,12 @@ class TestHyperparameters(unittest.TestCase):
         f2_actual = f1.to_integer()
         self.assertEqual(f2_expected, f2_actual)
 
+    def test_betafloat_pdf(self):
+        pass
+
+    def test_betafloat_get_max_density(self):
+        pass
+
     def test_uniforminteger(self):
         # TODO: rounding or converting or error message?
 
@@ -597,6 +621,12 @@ class TestHyperparameters(unittest.TestCase):
             ValueError,
             "Upper bound 1 must be larger than lower bound 0 for "
             "hyperparameter param", UniformIntegerHyperparameter, "param", 1, 0)
+
+    def test_uniformint_pdf(self):
+        pass
+
+    def test_uniformint_get_max_density(self):
+        pass
 
     def test_normalint(self):
         # TODO test for unequal!
@@ -707,6 +737,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertTrue(f1.is_legal_vector(-0.1))
         self.assertTrue(f1.is_legal_vector(1.1))
         self.assertRaises(TypeError, f1.is_legal_vector, "Hahaha")
+
+    def test_normalint_pdf(self):
+        pass
+
+    def test_normalint_get_max_density(self):
+        pass
 
     ############################################################
     def test_betaint(self):
@@ -840,6 +876,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertTrue(f1.is_legal_vector(-0.1))
         self.assertTrue(f1.is_legal_vector(1.1))
         self.assertRaises(TypeError, f1.is_legal_vector, "Hahaha")
+
+    def test_betaint_pdf(self):
+        pass
+
+    def test_betaint_get_max_density(self):
+        pass
 
     def test_categorical(self):
         # TODO test for inequality
@@ -997,6 +1039,12 @@ class TestHyperparameters(unittest.TestCase):
         self.assertTrue(np.isfinite(hp._upper))
         sample(hp)
 
+    def test_categorical_pdf(self):
+        pass
+
+    def test_categorical_get_max_density(self):
+        pass
+
     def test_sample_NormalFloatHyperparameter(self):
         hp = NormalFloatHyperparameter("nfhp", 0, 1)
 
@@ -1034,6 +1082,12 @@ class TestHyperparameters(unittest.TestCase):
             return counts_per_bin
 
         self.assertEqual(actual_test(), actual_test())
+
+    def test_sample_BetaFloatHyperparameter(self):
+        pass
+    
+    def test_sample_BetaFloatHyperparameter(self):
+        pass
 
     def test_sample_UniformIntegerHyperparameter(self):
         # TODO: disentangle, actually test _sample and test sample on the
@@ -1217,6 +1271,12 @@ class TestHyperparameters(unittest.TestCase):
         for i in range(100):
             values.append(hp._sample(rs))
         self.assertEqual(len(np.unique(values)), 5)
+
+    def test_sample_BetaIntegerHyperparameter(self):
+        pass
+    
+    def test_sample_BetaIntegerHyperparameter(self):
+        pass
 
     def test_sample_CategoricalHyperparameter(self):
         hp = CategoricalHyperparameter("chp", [0, 2, "Bla", u"Blub"])

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -287,30 +287,38 @@ class TestHyperparameters(unittest.TestCase):
         point_1 = np.array([3])
         point_2 = np.array([7])
         point_3 = np.array([0.3])
-        array_1 = np.array([3, 7])
+        array_1 = np.array([3, 7, 5])
         point_outside_range = np.array([-1])
         point_outside_range_log = np.array([0.1])
         wrong_shape_1 = np.array([[3]])
         wrong_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
         wrong_shape_3 = np.array([3, 5, 7]).reshape(-1, 1)
         
-        self.assertEqual(c1.pdf(point_1), np.array([0.1]))
-        self.assertEqual(c2.pdf(point_2), np.array([0.1]))
-        self.assertEqual(c1.pdf(point_1), np.array([0.1]))
-        self.assertEqual(c2.pdf(point_2), np.array([0.1]))
-        self.assertEqual(c3.pdf(point_3), np.array([2.0]))
+        self.assertAlmostEqual(c1.pdf(point_1)[0], 0.1)
+        self.assertAlmostEqual(c2.pdf(point_2)[0], 4.539992976248485e-05)
+        self.assertAlmostEqual(c1.pdf(point_1)[0], 0.1)
+        self.assertAlmostEqual(c2.pdf(point_2)[0], 4.539992976248485e-05)
+        self.assertAlmostEqual(c3.pdf(point_3)[0], 2.0)
         
         # TODO - change this once the is_legal support is there
         # but does not have an actual impact of now
         # since inverse_transform pulls everything into range, even points outside get evaluated in range
-        self.assertEqual(c1.pdf(point_outside_range), np.array([0.1]))
-        self.assertEqual(c2.pdf(point_outside_range_log), np.array([0.1]))
+        self.assertAlmostEqual(c1.pdf(point_outside_range)[0], 0.1)
+        self.assertAlmostEqual(c2.pdf(point_outside_range_log)[0], 4.539992976248485e-05)
 
         # this, however, is a negative value on a log param, which cannot be pulled into range
-        self.assertEqual(c2.pdf(point_outside_range), np.array([0.0]))
+        self.assertEqual(c2.pdf(point_outside_range)[0], 0.0)
         
-        self.assertEqual(tuple(c1.pdf(array_1)), tuple(np.array([0.1, 0.1])))
-        self.assertEqual(tuple(c2.pdf(array_1)), tuple(np.array([0.1, 0.1])))
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1)
+        expected_results = np.array([0.1, 0.1, 0.1])
+        expected_log_results = np.array([4.539992976248485e-05, 4.539992976248485e-05, 4.539992976248485e-05])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_log_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results_log, expected_results, expected_log_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_log_res)
+        
         
         # pdf must take a numpy array
         with self.assertRaises(TypeError):
@@ -340,22 +348,29 @@ class TestHyperparameters(unittest.TestCase):
         accepted_shape_2 = np.array([0.3, 0.5, 1.1]).reshape(1, -1)
         accepted_shape_3 = np.array([1.1, 0.5, 0.3]).reshape(-1, 1)
         
-        self.assertEqual(c1._pdf(point_1), np.array([0.1]))
-        self.assertEqual(c2._pdf(point_2), np.array([0.1]))
-        self.assertEqual(c1._pdf(point_1), np.array([0.1]))
-        self.assertEqual(c2._pdf(point_2), np.array([0.1]))
-        self.assertEqual(c3._pdf(point_3), np.array([2.0]))
+        self.assertAlmostEqual(c1._pdf(point_1)[0], 0.1)
+        self.assertAlmostEqual(c2._pdf(point_2)[0], 4.539992976248485e-05)
+        self.assertAlmostEqual(c1._pdf(point_1)[0], 0.1)
+        self.assertAlmostEqual(c2._pdf(point_2)[0], 4.539992976248485e-05)
+        self.assertAlmostEqual(c3._pdf(point_3)[0], 2.0)
         
         # TODO - change this once the is_legal support is there
         # but does not have an actual impact of now
         # since inverse_transform pulls everything into range, even points outside get evaluated in range
-        self.assertEqual(c1._pdf(point_outside_range_1), np.array([0.0]))
-        self.assertEqual(c2._pdf(point_outside_range_2), np.array([0.0]))
-        self.assertEqual(c1._pdf(point_outside_range_2), np.array([0.0]))
-        self.assertEqual(c2._pdf(point_outside_range_1), np.array([0.0]))
+        self.assertAlmostEqual(c1._pdf(point_outside_range_1)[0], 0.0)
+        self.assertAlmostEqual(c2._pdf(point_outside_range_2)[0], 0.0)
+        self.assertAlmostEqual(c1._pdf(point_outside_range_2)[0], 0.0)
+        self.assertAlmostEqual(c2._pdf(point_outside_range_1)[0], 0.0)
 
-        self.assertEqual(tuple(c1._pdf(array_1)), tuple(np.array([0.1, 0.1, 0.0])))
-        self.assertEqual(tuple(c2._pdf(array_1)), tuple(np.array([0.1, 0.1, 0.0])))
+        array_results = c1._pdf(array_1)
+        array_results_log = c2._pdf(array_1)
+        expected_results = np.array([0.1, 0.1, 0])
+        expected_log_results = np.array([4.539992976248485e-05, 4.539992976248485e-05, 0.0])
+        self.assertEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_log_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results_log, expected_results, expected_log_results):
+            self.assertAlmostEqual(res, exp_res)
+            self.assertAlmostEqual(log_res, exp_log_res)
         
         # pdf must take a numpy array
         with self.assertRaises(TypeError):
@@ -999,7 +1014,108 @@ class TestHyperparameters(unittest.TestCase):
             "hyperparameter param", UniformIntegerHyperparameter, "param", 1, 0)
 
     def test_uniformint_pdf(self):
-        pass
+        c1 = UniformIntegerHyperparameter("param", lower=0, upper=4)
+        c2 = UniformIntegerHyperparameter("logparam", lower=1, upper=10000, log=True)
+        c3 = UniformIntegerHyperparameter("param", lower=-1, upper=12)
+        point_1 = np.array([0])
+        point_1_log = np.array([1])
+        point_2 = np.array([3.0])
+        point_2_log = np.array([3.0])
+        non_integer_point = np.array([3.7])
+        array_1 = np.array([1, 3, 3.7])
+        point_outside_range = np.array([-1])
+        point_outside_range_log = np.array([10001])
+        wrong_shape_1 = np.array([[3]])
+        wrong_shape_2 = np.array([3, 5, 7]).reshape(1, -1)
+        wrong_shape_3 = np.array([3, 5, 7]).reshape(-1, 1)
+
+        # need to lower the amount of places since the bounds are inexact (._lower=-0.49999, ._upper=4.49999)
+        self.assertAlmostEqual(c1.pdf(point_1)[0], 0.2, places=5)
+        self.assertAlmostEqual(c2.pdf(point_1_log)[0], 0.0001, places=5)
+        self.assertAlmostEqual(c1.pdf(point_2)[0], 0.2, places=5)
+        self.assertAlmostEqual(c2.pdf(point_2_log)[0], 0.0001, places=5)
+        self.assertAlmostEqual(c1.pdf(non_integer_point)[0], 0.0, places=5)
+        self.assertAlmostEqual(c2.pdf(non_integer_point)[0], 0.0, places=5)
+        self.assertAlmostEqual(c3.pdf(point_1)[0], 0.07142857142857142, places=5)
+        
+        # TODO - change this once the is_legal support is there
+        # but does not have an actual impact of now
+        # since inverse_transform pulls everything into range, even points outside get evaluated in range
+        self.assertAlmostEqual(c1.pdf(point_outside_range)[0], 0.2, places=5)
+        self.assertAlmostEqual(c2.pdf(point_outside_range_log)[0], 0.0001, places=5)
+
+        # this, however, is a negative value on a log param, which cannot be pulled into range
+        self.assertEqual(c2.pdf(point_outside_range)[0], 0.0)
+        
+        array_results = c1.pdf(array_1)
+        array_results_log = c2.pdf(array_1)
+        expected_results = np.array([0.2, 0.2, 0])
+        expected_results_log = np.array([0.0001, 0.0001, 0])
+        self.assertAlmostEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results, expected_results, expected_results_log):
+            self.assertAlmostEqual(res, exp_res, places=5)
+            self.assertAlmostEqual(log_res, exp_res, places=5)
+
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1.pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1.pdf('pdf')
+
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_1)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_2)
+        with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
+            c1.pdf(wrong_shape_3)
+
+    def test_uniformint__pdf(self):
+        c1 = UniformIntegerHyperparameter("param", lower=0, upper=4)
+        c2 = UniformIntegerHyperparameter("logparam", lower=1, upper=10000, log=True)
+        c3 = UniformIntegerHyperparameter("param", lower=-1, upper=12)
+        point_1 = np.array([0])
+        point_2 = np.array([0.7])
+        array_1 = np.array([0, 0.7, 1.1])
+        point_outside_range = np.array([-0.1])
+        accepted_shape_1 = np.array([[0.7]])
+        accepted_shape_2 = np.array([0, 0.7, 1.1]).reshape(1, -1)
+        accepted_shape_3 = np.array([1.1, 0.7, 0]).reshape(-1, 1)
+
+        # need to lower the amount of places since the bounds are inexact (._lower=-0.49999, ._upper=4.49999)
+        self.assertAlmostEqual(c1._pdf(point_1)[0], 0.2, places=5)
+        self.assertAlmostEqual(c2._pdf(point_1)[0], 0.0001, places=5)
+        self.assertAlmostEqual(c1._pdf(point_2)[0], 0.2, places=5)
+        self.assertAlmostEqual(c2._pdf(point_2)[0], 0.0001, places=5)
+        
+        # TODO - change this once the is_legal support is there
+        # but does not have an actual impact of now
+        # since inverse_transform pulls everything into range, even points outside get evaluated in range
+        self.assertAlmostEqual(c1._pdf(point_outside_range)[0], 0.0, places=5)
+        self.assertAlmostEqual(c2._pdf(point_outside_range)[0], 0.0, places=5)
+        
+        array_results = c1._pdf(array_1)
+        array_results_log = c2._pdf(array_1)
+        expected_results = np.array([0.2, 0.2, 0])
+        expected_results_log = np.array([0.0001, 0.0001, 0])
+        self.assertAlmostEqual(array_results.shape, expected_results.shape)
+        self.assertEqual(array_results_log.shape, expected_results.shape)
+        for res, log_res, exp_res, exp_log_res in zip(array_results, array_results, expected_results, expected_results_log):
+            self.assertAlmostEqual(res, exp_res, places=5)
+            self.assertAlmostEqual(log_res, exp_res, places=5)
+
+        # pdf must take a numpy array
+        with self.assertRaises(TypeError):
+            c1._pdf(0.2)
+        with self.assertRaises(TypeError):
+            c1._pdf('pdf')
+   
+        # Simply check that it runs, since _pdf does not restrict shape (only public method does)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_1)[0][0], 0.2, places=5)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][0], 0.2, places=5)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_2)[0][2], 0.0, places=5)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[0][0], 0.0, places=5)
+        self.assertAlmostEqual(c1._pdf(accepted_shape_3)[2][0], 0.2, places=5)
 
     def test_uniformint_get_max_density(self):
         pass

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1874,19 +1874,22 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(actual_test(), actual_test())
 
     def test_sample_BetaFloatHyperparameter(self):
-        rs = np.random.RandomState(1)
-        f1 = BetaFloatHyperparameter("param", lower=-2.0, upper=2.0, alpha=1.2, beta=1.1)
-        f1_log = BetaFloatHyperparameter("param", lower=1, upper=1000, alpha=1.2, beta=1.1, log=True)
-        samples = f1._sample(rs=rs, size=10000)
-        samples_log = f1_log._sample(rs=rs, size=10000)
-        self.assertTrue(np.all(samples > f1._lower))
-        self.assertTrue(np.all(samples < f1._upper))
-        self.assertTrue(np.all(samples_log > f1_log._lower))
-        self.assertTrue(np.all(samples_log < f1_log._upper))
-    
-        for i in range(100):  
-            self.assertTrue((f1.sample(rs) > f1.lower) and (f1.sample(rs) < f1.upper))
-            self.assertTrue((f1_log.sample(rs) > f1_log.lower) and (f1_log.sample(rs) < f1_log.upper))
+        hp = BetaFloatHyperparameter("bfhp", alpha=8, beta=1.5, lower=-1, upper=10)
+
+        def actual_test():
+            rs = np.random.RandomState(1)
+            counts_per_bin = [0 for i in range(11)]
+            for i in range(1000):
+                value = hp.sample(rs)
+                index = np.floor(value).astype(int)
+                counts_per_bin[index] += 1
+
+            self.assertEqual([0, 2, 2, 4, 15, 39, 101, 193, 289, 355, 0], counts_per_bin)
+
+            self.assertIsInstance(value, float)
+            return counts_per_bin
+
+        self.assertEqual(actual_test(), actual_test())
 
     def test_sample_UniformIntegerHyperparameter(self):
         # TODO: disentangle, actually test _sample and test sample on the
@@ -2072,8 +2075,23 @@ class TestHyperparameters(unittest.TestCase):
         self.assertEqual(len(np.unique(values)), 5)
 
     def test_sample_BetaIntegerHyperparameter(self):
-        pass
+        hp = BetaIntegerHyperparameter("bihp", alpha=8, beta=1.5, lower=-1, upper=10)
 
+        def actual_test():
+            rs = np.random.RandomState(1)
+            counts_per_bin = [0 for i in range(11)]
+            for i in range(1000):
+                value = hp.sample(rs)
+                index = np.floor(value).astype(int)
+                counts_per_bin[index] += 1
+
+            self.assertEqual([0, 0, 2, 3, 7, 25, 63, 145, 248, 355, 152], counts_per_bin)
+
+            self.assertIsInstance(value, int)
+            return counts_per_bin
+
+        self.assertEqual(actual_test(), actual_test())
+        
     def test_sample_CategoricalHyperparameter(self):
         hp = CategoricalHyperparameter("chp", [0, 2, "Bla", u"Blub"])
 


### PR DESCRIPTION
## Added the beta parameter types, the accompanying imports and checks, and implemented the infrastructure for computing the pdf of a parameter


### High-level additions
__hyperparameters__: 
- added BetaFloat and BetaIntegerHyperparameter - they share the neighbor generation of their uniform counterparts. 
- Added pdf and _pdf for all parameters, where the logic is
pdf(vector) = _pdf(inverse_transform(vector)). This means that the user can call pdf(X) on the original parameter range, but the acquisition function calls _pdf, since it already recieves the transformed parameter ranges.
- The Beta parameters are not normalized to 0-1 range, which is simply because Normal was not, either. Not sure if this is the correct choice.
- The local searches are just copy-paste of the corresponding Uniform parameter types - with the exception that the jump from existing configuration is scaled by the range of the parameter (as it it not in 0-1, the jump presumably needs to reflect this)

__json__: added the necessary stuff for the new parameters to fit in with the rest
__configuration_space__: Added a method __remove_parameter_priors__ (previously to_uniform) to create a ConfigSpace of only uniform parameters - needed for the new local search approach in SMAC (see ei_optimization)

__user guide__: Added an (hopefully intuitive) example on how to use the prior parameter types, and for what purpose.

### Design choices (that I had to give some thought)
- the pdf function only accepts a (N, ) numpy array as input. This seems like it would be the most predictable for us. Could perhaps be given more thought, since _pdf really is the internal workhorse.
- The pdf/_pdf of the logged UniformFloat/Int parameters is _not_ a log-uniform distribution, but a uniform (in that it returns the same constant value for the entire search space). The thought behind this is that the user does not want to bias the search space if they use a Uniform, just have the parameter on a logscale. I also think this is the most intuitive.
- the pdf of an IntegerHyperparameter evaluated on a decimal number (not a rounded integer) returns zero. This should be most intuitive for the user. Once again, _pdf really does the job internally.
- Normal hyperparameters are not normalized to [0-1]-range internally. I assume this is due to the possibility of them being unbounded. I opted not to normalize Beta parameters as I did not see a direct reason to, and it was easier to work.
- A CategoricalHyperparameter now always carry probabilities (previously _None_), but these are not written out in the default (uniform weights) case. Some tests are adjusted to comply.

### Bugfixes (not my code)
- Previously incorrect sampling in the logged NormalFloatHyperparameter 

### Tests
- All pdf and _pdf functions: legal and illegal inputs, expected outputs for logged and unlogged variables
- sampling for betafloat and betainteger
- get_max_density for all parameters
- cs.remove_parameter_priors (test just for expected output) for when converting to a configspace without priors

I think that was it!