### PR TITLE
Add: Windows and mac testing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -163,7 +163,7 @@ jobs:
 
     - name: Install ${{ env.package-name }}
       run: |
-        python -m pip install -e ${{ env.sdist_name }}${{ env.extra-requires }}
+        python -m pip install ${{ env.sdist_name }}${{ env.extra-requires }}
 
     - name: Tests
       timeout-minutes: 45


### PR DESCRIPTION
Enables testing for windows and mac by making the using `shell: bash` in the workflow.