### PR TITLE
Allow using forbidden clauses with non-numeric values

### DIFF
--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -154,7 +154,7 @@ cdef class SingleValueForbiddenClause(AbstractForbiddenClause):
 
         return self._is_forbidden_vector(value)
 
-    cdef int _is_forbidden(self, float value):
+    cdef int _is_forbidden(self, value):
         pass
 
     cdef int _is_forbidden_vector(self, DTYPE_t value):
@@ -210,7 +210,7 @@ cdef class MultipleValueForbiddenClause(AbstractForbiddenClause):
 
         return self._is_forbidden_vector(value)
 
-    cdef int _is_forbidden(self, float value):
+    cdef int _is_forbidden(self, value):
         pass
 
     cdef int _is_forbidden_vector(self, DTYPE_t value):
@@ -250,7 +250,7 @@ cdef class ForbiddenEqualsClause(SingleValueForbiddenClause):
         return "Forbidden: %s == %s" % (self.hyperparameter.name,
                                         repr(self.value))
 
-    cdef int _is_forbidden(self, float value):
+    cdef int _is_forbidden(self, value):
         return value == self.value
 
     cdef int _is_forbidden_vector(self, DTYPE_t value):
@@ -303,7 +303,7 @@ cdef class ForbiddenInClause(MultipleValueForbiddenClause):
             "{" + ", ".join((repr(value)
                              for value in sorted(self.values))) + "}")
 
-    cdef int _is_forbidden(self, float value):
+    cdef int _is_forbidden(self, value):
         return value in self.values
 
     cdef int _is_forbidden_vector(self, DTYPE_t value):

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -90,6 +90,9 @@ class TestForbidden(unittest.TestCase):
         # print("\nneq9:")
         self.assertTrue(forb1.is_forbidden({'parent': 1}, True))
 
+        self.assertTrue(forb3.is_forbidden({'grandchild': 'hot'}, True))
+        self.assertFalse(forb3.is_forbidden({'grandchild': 'cold'}, True))
+
         # Test forbidden on vector values
         hyperparameter_idx = {
             hp1.name: 0,
@@ -153,6 +156,10 @@ class TestForbidden(unittest.TestCase):
         # print("\nTest8:")
         for i in range(5, 10):
             self.assertTrue(forb1.is_forbidden({'child': i}, True))
+
+        self.assertTrue(forb4.is_forbidden({'grandchild': 'hot'}, True))
+        self.assertTrue(forb4.is_forbidden({'grandchild': 'cold'}, True))
+        self.assertFalse(forb4.is_forbidden({'grandchild': 'warm'}, True))
 
         # Test forbidden on vector values
         hyperparameter_idx = {


### PR DESCRIPTION
# Before

Restricting a categorical hyperparameter with non-numeric (namely string) values by a forbidden clause `forbidden` and calling `forbidden.is_forbidden` on a relevant `instantiated_hyperparameters` dictionary raises the following exception:

```
TypeError: must be real number, not str
```

# After

Forbidden clauses that involve non-numeric hyperparameters can be evaluated using `is_forbidden` without raising an exception.