### PR TITLE
Fix bug introduced by #221: 

### DIFF
--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -37,7 +37,7 @@ from ConfigSpace.forbidden import (
 )
 
 
-JSON_FORMAT_VERSION = 0.2
+JSON_FORMAT_VERSION = 0.3
 
 
 ################################################################################

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -308,7 +308,7 @@ def write(configuration_space, indent=2):
 
         >>> with open('configspace.json', 'w') as f:
         ...      f.write(json.write(cs))
-        305
+        299
 
     Parameters
     ----------

--- a/ConfigSpace/read_and_write/pcs.py
+++ b/ConfigSpace/read_and_write/pcs.py
@@ -72,9 +72,9 @@ pp_forbidden_clause = "{" + pp_param_name + "=" + pp_numberorname + \
 
 
 def build_categorical(param):
-    if param.probabilities is not None:
+    if param.weights is not None:
         raise ValueError('The pcs format does not support categorical hyperparameters with '
-                         'assigend weights/probabilities (for hyperparameter %s)' % param.name)
+                         'assigend weights (for hyperparameter %s)' % param.name)
     cat_template = "%s {%s} [%s]"
     return cat_template % (param.name,
                            ", ".join([str(value) for value in param.choices]),

--- a/ConfigSpace/read_and_write/pcs.py
+++ b/ConfigSpace/read_and_write/pcs.py
@@ -74,7 +74,7 @@ pp_forbidden_clause = "{" + pp_param_name + "=" + pp_numberorname + \
 def build_categorical(param):
     if param.weights is not None:
         raise ValueError('The pcs format does not support categorical hyperparameters with '
-                         'assigend weights (for hyperparameter %s)' % param.name)
+                         'assigned weights (for hyperparameter %s)' % param.name)
     cat_template = "%s {%s} [%s]"
     return cat_template % (param.name,
                            ", ".join([str(value) for value in param.choices]),

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -110,7 +110,7 @@ pp_forbidden_clause = "{" + pp_param_name + "=" + pp_numberorname + \
 def build_categorical(param):
     if param.weights is not None:
         raise ValueError('The pcs format does not support categorical hyperparameters with '
-                         'assigend weights (for hyperparameter %s)' % param.name)
+                         'assigned weights (for hyperparameter %s)' % param.name)
     cat_template = "%s categorical {%s} [%s]"
     return cat_template % (param.name,
                            ", ".join([str(value) for value in param.choices]),

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -108,9 +108,9 @@ pp_forbidden_clause = "{" + pp_param_name + "=" + pp_numberorname + \
 
 
 def build_categorical(param):
-    if param.probabilities is not None:
+    if param.weights is not None:
         raise ValueError('The pcs format does not support categorical hyperparameters with '
-                         'assigend weights/probabilities (for hyperparameter %s)' % param.name)
+                         'assigend weights (for hyperparameter %s)' % param.name)
     cat_template = "%s categorical {%s} [%s]"
     return cat_template % (param.name,
                            ", ".join([str(value) for value in param.choices]),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ Basic usage
     >>> cs.sample_configuration()
     Configuration(values={
       'a': 27,
-      'b': 'blue',
+      'b': 'green',
     })
     <BLANKLINE>
 


### PR DESCRIPTION
now, PCS can be serialized again if no weight was given