### PR TITLE
Hyperparameter PDFs an Densities

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1344,6 +1344,31 @@ class ConfigurationSpace(collections.abc.Mapping):
         """
         self.random = np.random.RandomState(seed)
 
+    def remove_hyperparameter_priors(self) -> 'ConfigurationSpace':
+        """
+        Produces a new ConfigurationSpace where all priors on parameters are removed.
+        Non-uniform hyperpararmeters are replaced with uniform ones, and 
+        CategoricalHyperparameters with weights have their weights removed. 
+        
+        Returns
+        -------
+        :class:`~ConfigSpace.configuration_space.ConfigurationSpace`
+            The resulting configuration space, without priors on the hyperparameters
+        """
+        uniform_config_space = ConfigurationSpace()
+        for parameter in self.get_hyperparameters():
+            if hasattr(parameter, 'to_uniform'):
+                uniform_config_space.add_hyperparameter(parameter.to_uniform())
+            else:
+                uniform_config_space.add_hyperparameter(copy.copy(parameter))
+        
+        new_conditions = self.substitute_hyperparameters_in_conditions(self.get_conditions(), uniform_config_space)
+        new_forbiddens = self.substitute_hyperparameters_in_forbiddens(self.get_forbiddens(), uniform_config_space)
+        uniform_config_space.add_conditions(new_conditions)
+        uniform_config_space.add_forbidden_clauses(new_forbiddens)
+        
+        return uniform_config_space
+
     def estimate_size(self) -> Union[float, int]:
         """
         Estimate the size of the current configuration space (i.e. unique configurations).
@@ -1369,6 +1394,102 @@ class ConfigurationSpace(collections.abc.Mapping):
             for i in range(1, len(sizes)):
                 size = size * sizes[i]
             return size
+
+    @staticmethod
+    def substitute_hyperparameters_in_conditions(conditions, new_configspace) -> List['ConditionComponent']:
+        """
+        Takes a set of conditions and generates a new set of conditions with the same structure, where 
+        each hyperparameter is replaced with its namesake in new_configspace. As such, the set of conditions
+        remain unchanged, but the included hyperparameters are changed to match those types that exist in
+        new_configspace.
+
+        Parameters
+        ----------
+        new_configspace: ConfigurationSpace 
+            A ConfigurationSpace containing hyperparameters with the same names as those in the conditions.
+
+        Returns
+        -------
+        List[ConditionComponent]: 
+            The list of conditions, adjusted to fit the new ConfigurationSpace
+        """    
+        new_conditions = []
+        for condition in conditions:
+            if isinstance(condition, AbstractConjunction):
+                conjunction_type = type(condition)
+                children = condition.get_descendant_literal_conditions()
+                substituted_children = ConfigurationSpace.substitute_hyperparameters_in_conditions(children, new_configspace)
+                substituted_conjunction = conjunction_type(*substituted_children)
+                new_conditions.append(substituted_conjunction)
+            
+            elif isinstance(condition, AbstractCondition):
+                condition_type = type(condition)
+                child_name = getattr(condition.get_children()[0], 'name')
+                parent_name = getattr(condition.get_parents()[0], 'name')
+                new_child = new_configspace[child_name]
+                new_parent = new_configspace[parent_name]
+                
+                if hasattr(condition, 'value'):
+                    condition_arg = getattr(condition, 'value')
+                    substituted_condition = condition_type(child=new_child, parent=new_parent, value=condition_arg)
+                elif hasattr(condition, 'values'):
+                    condition_arg = getattr(condition, 'values')
+                    substituted_condition = condition_type(child=new_child, parent=new_parent, values=condition_arg)
+                else:
+                    raise AttributeError(f'Did not find the expected attribute in condition {type(condition)}.')
+                
+                new_conditions.append(substituted_condition)
+            else:
+                raise TypeError(f'Did not expect the supplied condition type {type(condition)}.')
+                
+        return new_conditions
+
+    @staticmethod
+    def substitute_hyperparameters_in_forbiddens(forbiddens, new_configspace) -> List['ConditionComponent']:
+        """
+        Takes a set of forbidden clauses and generates a new set of forbidden clauses with the same structure, 
+        where each hyperparameter is replaced with its namesake in new_configspace. As such, the set of forbidden 
+        clauses remain unchanged, but the included hyperparameters are changed to match those types that exist in
+        new_configspace.
+
+        Parameters
+        ----------
+        new_configspace: ConfigurationSpace 
+            A ConfigurationSpace containing hyperparameters with the same names as those in the forbidden clauses.
+
+        Returns
+        -------
+        List[AbstractForbiddenComponent]: 
+            The list of forbidden clauses, adjusted to fit the new ConfigurationSpace
+        """    
+        new_forbiddens = []
+        for forbidden in forbiddens:
+            if isinstance(forbidden, AbstractForbiddenConjunction):
+                conjunction_type = type(forbidden)
+                children = forbidden.get_descendant_literal_clauses()
+                substituted_children = ConfigurationSpace.substitute_hyperparameters_in_forbiddens(children, new_configspace)
+                substituted_conjunction = conjunction_type(*substituted_children)
+                new_forbiddens.append(substituted_conjunction)
+            
+            elif isinstance(forbidden, AbstractForbiddenClause):
+                forbidden_type = type(forbidden)
+                hyperparameter_name = getattr(forbidden.hyperparameter, 'name')
+                new_hyperparameter = new_configspace[hyperparameter_name]
+                
+                if hasattr(forbidden, 'value'):
+                    forbidden_arg = getattr(forbidden, 'value')
+                    substituted_forbidden = forbidden_type(hyperparameter=new_hyperparameter, value=forbidden_arg)
+                elif hasattr(forbidden, 'values'):
+                    forbidden_arg = getattr(forbidden, 'values')
+                    substituted_forbidden = forbidden_type(hyperparameter=new_hyperparameter, values=forbidden_arg)
+                else:
+                    raise AttributeError(f'Did not find the expected attribute in forbidden {type(forbidden)}.')
+                
+                new_forbiddens.append(substituted_forbidden)
+            else:
+                raise TypeError(f'Did not expect the supplied forbidden type {type(forbidden)}.')
+        
+        return new_forbiddens
 
 
 class Configuration(collections.abc.Mapping):

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -12,7 +12,7 @@
 #       notice, this list of conditions and the following disclaimer in the
 #       documentation and/or other materials provided with the distribution.
 #     * Neither the name of the <organization> nor the
-#       names of its contributors may be used to endorse or promote products
+#       names of itConfigurationSpaces contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -151,6 +151,49 @@ cdef class Hyperparameter(object):
     cpdef int compare_vector(self, DTYPE_t value, DTYPE_t value2):
         raise NotImplementedError()
 
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the hyperparameter in 
+        the hyperparameter space (the one specified by the user).
+        For each hyperparameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) hyperparameter
+        space. Only legal values return a positive probability density,
+        otherwise zero.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        raise NotImplementedError()
+        
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the hyperparameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+         in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        raise NotImplementedError()
+
     def get_size(self) -> float:
         raise NotImplementedError()
 
@@ -261,6 +304,54 @@ cdef class Constant(Hyperparameter):
     def get_neighbors(self, value: Any, rs: np.random.RandomState, number: int,
                       transform: bool = False) -> List:
         return []
+
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the original parameter space (the one specified by the user).
+        For each hyperparameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) parameter
+        space. Only legal values return a positive probability density,
+        otherwise zero.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+                    
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        if vector.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+        return self._pdf(vector)
+
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        return (vector == self.value).astype(float)
+
+    def get_max_density(self):
+        return 1.0
 
     def get_size(self) -> float:
         return 1.0
@@ -378,6 +469,60 @@ cdef class FloatHyperparameter(NumericalHyperparameter):
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         raise NotImplementedError()
 
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the original parameter space (the one specified by the user).
+        For each parameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) parameter
+        space. Only legal values return a positive probability density,
+        otherwise zero.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+                    
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        if vector.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+        vector = self._inverse_transform(vector)
+        return self._pdf(vector)
+        
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        raise NotImplementedError()
+
+    def get_max_density(self) -> float:
+        """
+        Returns the maximal density on the pdf for the parameter (so not 
+        the mode, but the value of the pdf on the mode).
+        """
+        raise NotImplementedError()
+
+
 
 cdef class IntegerHyperparameter(NumericalHyperparameter):
     def __init__(self, name: str, default_value: int, meta: Optional[Dict] = None) -> None:
@@ -415,6 +560,62 @@ cdef class IntegerHyperparameter(NumericalHyperparameter):
     cpdef np.ndarray _transform_vector(self, np.ndarray vector):
         raise NotImplementedError()
     
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the hyperparameter in 
+        the hyperparameter space (the one specified by the user).
+        For each hyperparameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) hyperparameter
+        space. Only legal values return a positive probability density,
+        otherwise zero.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+                    
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        if vector.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+        is_integer = (np.round(vector) == vector).astype(int)
+        vector = self._inverse_transform(vector)
+        return self._pdf(vector) * is_integer
+        
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). Optimally, an IntegerHyperparameter
+        should have a corresponding float, which can be utlized for the calls
+        to the probability density function (see e.g. NormalIntegerHyperparameter)
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        raise NotImplementedError()
+        
+    def get_max_density(self) -> float:
+        """
+        Returns the maximal density on the pdf for the parameter (so not 
+        the mode, but the value of the pdf on the mode).
+        """
+        raise NotImplementedError()
+
 
 cdef class UniformFloatHyperparameter(FloatHyperparameter):
     def __init__(self, name: str, lower: Union[int, float], upper: Union[int, float],
@@ -612,6 +813,36 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
                 neighbors.append(neighbor)
         return neighbors
 
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        # everything that comes into _pdf for a uniform variable should
+        # already be in [0, 1]-range, and if not, it's outside the upper
+        # or lower bound.
+        ub = 1
+        lb = 0
+        inside_range = ((lb <= vector) & (vector <= ub)).astype(int)
+        return inside_range / (self.upper - self.lower)
+
+    def get_max_density(self) -> float:
+        return 1 / (self.upper - self.lower)
+        
     def get_size(self) -> float:
         if self.q is None:
             return np.inf
@@ -890,6 +1121,50 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         else:
             return np.rint((self.upper - self.lower) / self.q) + 1
 
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """        
+        mu = self.mu
+        sigma = self.sigma
+        if self.lower == None:
+            return norm(loc=mu, scale=sigma).pdf(vector)
+        else:
+            mu = self.mu
+            sigma = self.sigma
+            lower = self._lower
+            upper = self._upper
+            a = (lower - mu) / sigma
+            b = (upper - mu) / sigma
+            
+            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
+
+    def get_max_density(self) -> float:
+        if self.lower is None:
+            return self._pdf(np.array([self.mu]))[0]
+
+        if self.mu < self._lower:
+            return self._pdf(np.array([self._lower]))[0]
+        elif self.mu > self._upper:
+            return self._pdf(np.array([self._upper]))[0]
+        else:
+            return self._pdf(np.array([self.mu]))[0]
+
 
 cdef class BetaFloatHyperparameter(UniformFloatHyperparameter):
     cdef public alpha
@@ -1034,11 +1309,15 @@ cdef class BetaFloatHyperparameter(UniformFloatHyperparameter):
         if default_value is None:
             if (self.alpha > 1) or (self.beta > 1):
                 normalized_mode = (self.alpha - 1) / (self.alpha + self.beta - 2)
-                return self._transform_scalar(normalized_mode)
             else: 
                 # If both alpha and beta are 1, we have a uniform distribution.
-                return self._transform_scalar(0.5)
-
+                normalized_mode = 0.5
+            
+            ub = self._inverse_transform(self.upper)
+            lb = self._inverse_transform(self.lower)
+            scaled_mode = normalized_mode * (ub - lb) + lb
+            return self._transform_scalar(scaled_mode)
+        
         elif self.is_legal(default_value):
             return default_value
         else:
@@ -1072,7 +1351,50 @@ cdef class BetaFloatHyperparameter(UniformFloatHyperparameter):
         beta = self.beta
         return spbeta(alpha, beta).rvs(size=size, random_state=rs)
 
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these).
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        ub = self._inverse_transform(self.upper)
+        lb = self._inverse_transform(self.lower)
+        alpha = self.alpha
+        beta = self.beta
+        return spbeta(alpha, beta, loc=lb, scale=ub-lb).pdf(vector) \
+        * (ub-lb) / (self._upper - self._lower)
 
+    def get_max_density(self) -> float:
+        if (self.alpha > 1) or (self.beta > 1):
+            normalized_mode = (self.alpha - 1) / (self.alpha + self.beta - 2)
+        elif self.alpha < self.beta:
+            normalized_mode = 0
+        elif self.alpha > self.beta:
+            normalized_mode = 1
+        else: 
+            normalized_mode = 0.5
+
+        ub = self._inverse_transform(self.upper)
+        lb = self._inverse_transform(self.lower)
+        scaled_mode = normalized_mode * (ub - lb) + lb
+
+        # Since _pdf takes only a numpy array, we have to create the array, 
+        # and retrieve the element in the first (and only) spot in the array
+        return self._pdf(np.array([scaled_mode]))[0]
+        
 cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
     def __init__(self, name: str, lower: int, upper: int, default_value: Union[int, None] = None,
                  q: Union[int, None] = None, log: bool = False,
@@ -1324,6 +1646,34 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
 
         return neighbors
 
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). Optimally, an IntegerHyperparameter
+        should have a corresponding float, which can be utlized for the calls
+        to the probability density function (see e.g. NormalIntegerHyperparameter)
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        return self.ufhp._pdf(vector)
+
+    def get_max_density(self) -> float:
+        lb = self.lower
+        ub = self.upper
+        return 1 / (ub - lb + 1)
+
     def get_size(self) -> float:
         if self.q is None:
             q = 1
@@ -1336,6 +1686,8 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
     cdef public mu
     cdef public sigma
     cdef public nfhp
+    cdef normalization_constant
+
 
     def __init__(self, name: str, mu: int, sigma: Union[int, float],
                  default_value: Union[int, None] = None, q: Union[None, int] = None,
@@ -1434,6 +1786,12 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
         self.default_value = self.check_default(default_value)
         self.normalized_default_value = self._inverse_transform(self.default_value)
         
+        if (self.lower is None) or (self.upper is None):
+            # Since a bound is missing, the pdf cannot be normalized. Working with the unnormalized variant)
+            self.normalization_constant = 1
+        else:
+            self.normalization_constant = self._compute_normalization()
+
     def __repr__(self) -> str:
         repr_str = io.StringIO()
 
@@ -1581,6 +1939,45 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
                 neighbors.append(new_value)
         return neighbors
         
+    def _compute_normalization(self):
+        if self.lower is None:
+            warnings.warn('Cannot normalize the pdf exactly for a NormalIntegerHyperparameter'
+            f' {self.name} without bounds. Skipping normalization for that hyperparameter.')
+            return 1
+
+        else:
+            all_integer_values = np.arange(self.lower, self.upper + 1)
+            all_probabilities = self.nfhp.pdf(all_integer_values)
+            return np.sum(all_probabilities)
+
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). Optimally, an IntegerHyperparameter
+        should have a corresponding float, which can be utlized for the calls
+        to the probability density function (see e.g. NormalIntegerHyperparameter)
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        return self.nfhp._pdf(vector) / self.normalization_constant
+
+    def get_max_density(self):
+        all_integer_values = np.arange(self.lower, self.upper + 1)
+        all_probabilities = self.nfhp.pdf(all_integer_values)
+        return np.max(all_probabilities) / self.normalization_constant
+
     def get_size(self) -> float:
         if self.lower is None:
             return np.inf
@@ -1596,6 +1993,8 @@ cdef class BetaIntegerHyperparameter(UniformIntegerHyperparameter):
     cdef public alpha
     cdef public beta
     cdef public bfhp
+    cdef normalization_constant
+
 
     def __init__(self, name: str, alpha: Union[int, float], beta: Union[int, float],
                  lower: Union[int, float],
@@ -1655,18 +2054,23 @@ cdef class BetaIntegerHyperparameter(UniformIntegerHyperparameter):
         if (alpha < 1) or (beta < 1):
             raise ValueError("Please provide values of alpha and beta larger than or equal to\
              1 so that the probability density is finite.")
+        if self.q is None:
+            q = 1
+        else:
+            q = self.q
         self.bfhp = BetaFloatHyperparameter(self.name,
                                               self.alpha,
                                               self.beta,
                                               log=self.log,
-                                              q=self.q,
+                                              q=q,
                                               lower=self.lower,
                                               upper=self.upper,
                                               default_value=self.default_value)
 
         self.default_value = self.check_default(default_value)
         self.normalized_default_value = self._inverse_transform(self.default_value)
-        
+        self.normalization_constant = self._compute_normalization()
+
     def __repr__(self) -> str:
         repr_str = io.StringIO()
         repr_str.write("%s, Type: BetaInteger, Alpha: %s Beta: %s, Range: [%s, %s], Default: %s" % (self.name, repr(self.alpha), repr(self.beta), repr(self.lower), repr(self.upper), repr(self.default_value)))
@@ -1752,6 +2156,38 @@ cdef class BetaIntegerHyperparameter(UniformIntegerHyperparameter):
         value = self._inverse_transform(value)
         return value
 
+    def _compute_normalization(self):
+        all_integer_values = np.arange(self.lower, self.upper + 1)
+        all_probabilities = self.bfhp.pdf(all_integer_values)
+        return np.sum(all_probabilities)
+
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). Optimally, an IntegerHyperparameter
+        should have a corresponding float, which can be utlized for the calls
+        to the probability density function (see e.g. NormalIntegerHyperparameter)
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        return self.bfhp._pdf(vector) / self.normalization_constant
+
+    def get_max_density(self):
+        all_integer_values = np.arange(self.lower, self.upper + 1)
+        all_probabilities = self.bfhp.pdf(all_integer_values)
+        return np.max(all_probabilities) / self.normalization_constant
 
 
 cdef class CategoricalHyperparameter(Hyperparameter):
@@ -2071,6 +2507,63 @@ cdef class CategoricalHyperparameter(Hyperparameter):
                          "OrdinalHyperparameter, but is "
                          "<cdef class 'ConfigSpace.hyperparameters.CategoricalHyperparameter'>")
 
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the original parameter space (the one specified by the user).
+        For each parameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) parameter
+        space. Only legal values return a positive probability density,
+        otherwise zero.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        # this check is to ensure shape is right (and np.shape does not work in cython)
+        if vector.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+        vector = np.array(self._inverse_transform(vector))
+        return self._pdf(vector)
+        
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the parameter in 
+        the transformed (and possibly normalized, depends on the parameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). For categoricals, each vector gets 
+        transformed to its corresponding index (but in float form). To be 
+        able to retrieve the element corresponding to the index, the float 
+        must be cast to int. 
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        probs = np.array(self.probabilities)
+        res = np.array(probs[vector.astype(int)])
+        if res.ndim == 0:
+            return res.reshape(-1)
+        return res
+
+    def get_max_density(self) -> float:
+        return np.max(self.probabilities)
+
     def get_size(self) -> float:
         return len(self.choices)
 
@@ -2360,6 +2853,58 @@ cdef class OrdinalHyperparameter(Hyperparameter):
 
     def allow_greater_less_comparison(self) -> bool:
         return True
+
+    def pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the hyperparameter in 
+        the original hyperparameter space (the one specified by the user).
+        For each parameter type, there is also a method _pdf which 
+        operates on the transformed (and possibly normalized) hyperparameter
+        space. Only legal values return a positive probability density,
+        otherwise zero. The OrdinalHyperparameter is treated
+        as a UniformHyperparameter with regard to its probability density.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        if vector.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+        return self._pdf(vector)
+        
+    def _pdf(self, vector: np.ndarray) -> np.ndarray:
+        """
+        Computes the probability density function of the hyperparameter in 
+        the transformed (and possibly normalized, depends on the hyperparameter 
+        type) space. As such, one never has to worry about log-normal 
+        distributions, only normal distributions (as the inverse_transform
+        in the pdf method handles these). The OrdinalHyperparameter is treated
+        as a UniformHyperparameter with regard to its probability density.
+        
+        Parameters
+        ----------
+        vector: np.ndarray
+            the (N, ) vector of inputs for which the probability density
+            function is to be computed.
+        
+        Returns
+        ----------
+        np.ndarray(N, )
+            Probability density values of the input vector
+        """
+        if not np.all(np.isin(vector, self.sequence)):
+            raise ValueError(f'Some element in the vector {vector} is not in the sequence {self.sequence}.')
+        return np.ones_like(vector, dtype=np.float64) / self.num_elements
+
+    def get_max_density(self) -> float:
+        return 1 / self.num_elements
 
     def get_size(self) -> float:
         return len(self.sequence)

--- a/docs/source/User-Guide.rst
+++ b/docs/source/User-Guide.rst
@@ -242,3 +242,41 @@ To read it from file
     >>> with open('configspace.json', 'r') as fh:
     ...     json_string = fh.read()
     ...     restored_conf = json.read(json_string)
+
+
+
+5th Example: Placing priors on the hyperparameters
+-------------------------
+
+If you want to conduct black-box optimization in SMAC (https://arxiv.org/abs/2109.09831), and you have prior knowledge about the which regions of the search space are more likely to contain the optimum, you may include this knowledge when designing the configuration space. More specifically, you place prior distributions over the optimum on the parameters, either by a (log)-normal or (log)-Beta distribution. SMAC then considers the given priors through the optimization by using PiBO (https://openreview.net/forum?id=MMAeCXIa89). 
+
+Consider the case of optimizing the accuracy of an MLP with three hyperparameters: learning rate [1e-5, 1e-1], dropout [0, 0.99] and activation {Tanh, ReLU}. From prior experience, you believe the optimal learning rate to be around 1e-3, a good dropout to be around 0.25, and the optimal activation function to be ReLU about 80% of the time. This can be represented accordingly:
+
+>>> import numpy as np
+>>> import ConfigSpace.hyperparameters as CSH
+>>> from ConfigSpace.configuration_space import ConfigurationSpace
+>>> # convert 10 log to natural log for learning rate, mean 1e-3
+>>> logmean = np.log(1e-3)
+>>> # two standard deviations on either side of the mean to cover the search space
+>>> logstd = np.log(10.0) 
+>>> learning_rate = CSH.NormalFloatHyperparameter(name='learning_rate', lower=1e-5, upper=1e-1, default_value=1e-3, mu=logmean, sigma=logstd, log=True)
+>>> dropout = CSH.BetaFloatHyperparameter(name='dropout', lower=0, upper=0.99, default_value=0.25, alpha=2, beta=4, log=False)
+>>> activation = CSH.CategoricalHyperparameter(name='activation', choices=['tanh', 'relu'], weights=[0.2, 0.8])
+
+>>> cs = ConfigurationSpace()
+>>> cs.add_hyperparameters([learning_rate, dropout, activation])
+[learning_rate, Type: NormalFloat, Mu: -6.907755278982137 Sigma: 2.302585092994046, Range: [1e-05, 0.1], Default: 0.001, on log-scale, dropout, Type: BetaFloat, Alpha: 2.0 Beta: 4.0, Range: [0.0, 0.99], Default: 0.25, activation, Type: Categorical, Choices: {tanh, relu}, Default: tanh, Probabilities: (0.2, 0.8)]
+
+To check that your prior makes sense for each hyperparameter, you can easily do so with the __pdf__ method. There, you will see that the probability of the optimal learning rate peaks at 10^-3, and decays as we go further away from it:
+
+>>> test_points = np.logspace(-5, -1, 5) 
+>>> test_points
+array([1.e-05, 1.e-04, 1.e-03, 1.e-02, 1.e-01])
+
+# the pdf function accepts an (N, ) numpy array as input.                 
+>>> learning_rate.pdf(test_points)
+array([0.02456573, 0.11009594, 0.18151753, 0.11009594, 0.02456573])
+
+
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ Basic usage
     >>> cs.sample_configuration()
     Configuration(values={
       'a': 27,
-      'b': 'blue',
+      'b': 'green',
     })
     <BLANKLINE>
 

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -41,7 +41,9 @@ from ConfigSpace import (ConfigurationSpace,
                          ForbiddenAndConjunction)
 from ConfigSpace.hyperparameters import (UniformFloatHyperparameter,
                                          NormalFloatHyperparameter,
+                                         BetaFloatHyperparameter,
                                          NormalIntegerHyperparameter,
+                                         BetaIntegerHyperparameter,
                                          OrdinalHyperparameter)
 from ConfigSpace.exceptions import ForbiddenValueError
 
@@ -805,6 +807,123 @@ class TestConfigurationSpace(unittest.TestCase):
         assert list(d.values()) == hyperparameters
         assert list(d.items()) == list(zip(names, hyperparameters))
         assert len(d) == 5
+
+    def test_remove_hyperparameter_priors(self):
+        cs = ConfigurationSpace()
+        integer = UniformIntegerHyperparameter('integer', 1, 5, log=True)
+        cat = CategoricalHyperparameter('cat', [0, 1, 2], weights=[1, 2, 3])
+        beta = BetaFloatHyperparameter("beta", alpha=8, beta=2, lower=-1, upper=11)
+        norm = NormalIntegerHyperparameter("norm", mu=5, sigma=4, lower=1, upper=15)
+        cs.add_hyperparameters([integer, cat, beta, norm])
+        cat_default = cat.default_value
+        norm_default = norm.default_value
+        beta_default = beta.default_value
+
+        # add some conditions, to test that remove_parameter_priors keeps the forbiddens
+        cond_1 = EqualsCondition(norm, cat, 2)
+        cond_2 = OrConjunction(EqualsCondition(beta, cat, 0),
+                               EqualsCondition(beta, cat, 1))
+        cond_3 = OrConjunction(EqualsCondition(norm, integer, 1),
+                               EqualsCondition(norm, integer, 3),
+                               EqualsCondition(norm, integer, 5))
+        cs.add_conditions([cond_1, cond_2, cond_3])
+
+        # add some forbidden clauses too, to test that remove_parameter_priors keeps the forbiddens
+        forbidden_clause_a = ForbiddenEqualsClause(cat, 0)
+        forbidden_clause_c = ForbiddenEqualsClause(integer, 3)
+        forbidden_clause_d = ForbiddenAndConjunction(forbidden_clause_a, forbidden_clause_c)
+        cs.add_forbidden_clauses([forbidden_clause_c, forbidden_clause_d])
+        uniform_cs = cs.remove_hyperparameter_priors()
+
+        expected_cs = ConfigurationSpace()
+        unif_integer = UniformIntegerHyperparameter('integer', 1, 5, log=True)
+        unif_cat = CategoricalHyperparameter('cat', [0, 1, 2], default_value=cat_default)
+
+        unif_beta = UniformFloatHyperparameter(
+            "beta", lower=-1, upper=11, default_value=beta_default)
+        unif_norm = UniformIntegerHyperparameter(
+            "norm", lower=1, upper=15, default_value=norm_default)
+        expected_cs.add_hyperparameters([unif_integer, unif_cat, unif_beta, unif_norm])
+
+        # add some conditions, to test that remove_parameter_priors keeps the forbiddens
+        cond_1 = EqualsCondition(unif_norm, unif_cat, 2)
+        cond_2 = OrConjunction(EqualsCondition(unif_beta, unif_cat, 0),
+                               EqualsCondition(unif_beta, unif_cat, 1))
+        cond_3 = OrConjunction(EqualsCondition(unif_norm, unif_integer, 1),
+                               EqualsCondition(unif_norm, unif_integer, 3),
+                               EqualsCondition(unif_norm, unif_integer, 5))
+        expected_cs.add_conditions([cond_1, cond_2, cond_3])
+
+        # add some forbidden clauses too, to test that remove_parameter_priors keeps the forbiddens
+        forbidden_clause_a = ForbiddenEqualsClause(unif_cat, 0)
+        forbidden_clause_c = ForbiddenEqualsClause(unif_integer, 3)
+        forbidden_clause_d = ForbiddenAndConjunction(forbidden_clause_a, forbidden_clause_c)
+        expected_cs.add_forbidden_clauses([forbidden_clause_c, forbidden_clause_d])
+
+        # __eq__ not implemented, so this is the next best thing
+        self.assertEqual(repr(uniform_cs), repr(expected_cs))
+
+    def test_substitute_hyperparameters_in_conditions(self):
+        cs1 = ConfigurationSpace()
+        orig_hp1 = CategoricalHyperparameter("input1", [0, 1])
+        orig_hp2 = CategoricalHyperparameter("input2", [0, 1])
+        orig_hp3 = UniformIntegerHyperparameter("child1", 0, 10)
+        orig_hp4 = UniformIntegerHyperparameter("child2", 0, 10)
+        cs1.add_hyperparameters([orig_hp1, orig_hp2, orig_hp3, orig_hp4])
+        cond1 = EqualsCondition(orig_hp2, orig_hp3, 0)
+        cond2 = EqualsCondition(orig_hp1, orig_hp3, 5)
+        cond3 = EqualsCondition(orig_hp1, orig_hp4, 1)
+        andCond = AndConjunction(cond2, cond3)
+        cs1.add_conditions([cond1, andCond])
+
+        cs2 = ConfigurationSpace()
+        sub_hp1 = CategoricalHyperparameter("input1", [0, 1, 2])
+        sub_hp2 = CategoricalHyperparameter("input2", [0, 1, 3])
+        sub_hp3 = NormalIntegerHyperparameter("child1", lower=0, upper=10, mu=5, sigma=2)
+        sub_hp4 = BetaIntegerHyperparameter("child2", lower=0, upper=10, alpha=3, beta=5)
+        cs2.add_hyperparameters([sub_hp1, sub_hp2, sub_hp3, sub_hp4])
+        new_conditions = cs1.substitute_hyperparameters_in_conditions(cs1.get_conditions(), cs2)
+
+        test_cond1 = EqualsCondition(sub_hp2, sub_hp3, 0)
+        test_cond2 = EqualsCondition(sub_hp1, sub_hp3, 5)
+        test_cond3 = EqualsCondition(sub_hp1, sub_hp4, 1)
+        test_andCond = AndConjunction(test_cond2, test_cond3)
+        cs2.add_conditions([test_cond1, test_andCond])
+        test_conditions = cs2.get_conditions()
+
+        self.assertEqual(new_conditions[0], test_conditions[0])
+        self.assertEqual(new_conditions[1], test_conditions[1])
+
+    def test_substitute_hyperparameters_in_forbiddens(self):
+        cs1 = ConfigurationSpace()
+        orig_hp1 = CategoricalHyperparameter("input1", [0, 1])
+        orig_hp2 = CategoricalHyperparameter("input2", [0, 1])
+        orig_hp3 = UniformIntegerHyperparameter("input3", 0, 10)
+        orig_hp4 = UniformIntegerHyperparameter("input4", 0, 10)
+        cs1.add_hyperparameters([orig_hp1, orig_hp2, orig_hp3, orig_hp4])
+        forb_1 = ForbiddenEqualsClause(orig_hp1, 0)
+        forb_2 = ForbiddenEqualsClause(orig_hp2, 1)
+        forb_3 = ForbiddenEqualsClause(orig_hp3, 10)
+        forb_4 = ForbiddenAndConjunction(forb_1, forb_2)
+        cs1.add_forbidden_clauses([forb_3, forb_4])
+
+        cs2 = ConfigurationSpace()
+        sub_hp1 = CategoricalHyperparameter("input1", [0, 1, 2])
+        sub_hp2 = CategoricalHyperparameter("input2", [0, 1, 3])
+        sub_hp3 = NormalIntegerHyperparameter("input3", lower=0, upper=10, mu=5, sigma=2)
+        sub_hp4 = BetaIntegerHyperparameter("input4", lower=0, upper=10, alpha=3, beta=5)
+        cs2.add_hyperparameters([sub_hp1, sub_hp2, sub_hp3, sub_hp4])
+        new_forbiddens = cs1.substitute_hyperparameters_in_forbiddens(cs1.get_forbiddens(), cs2)
+
+        test_forb_1 = ForbiddenEqualsClause(sub_hp1, 0)
+        test_forb_2 = ForbiddenEqualsClause(sub_hp2, 1)
+        test_forb_3 = ForbiddenEqualsClause(sub_hp3, 10)
+        test_forb_4 = ForbiddenAndConjunction(test_forb_1, test_forb_2)
+        cs2.add_forbidden_clauses([test_forb_3, test_forb_4])
+        test_forbiddens = cs2.get_forbiddens()
+
+        self.assertEqual(new_forbiddens[1], test_forbiddens[1])
+        self.assertEqual(new_forbiddens[0], test_forbiddens[0])
 
     def test_estimate_size(self):
         cs = ConfigurationSpace()


### PR DESCRIPTION
# PiBO Pull Request 3 remake - PDFs and Densities

### Third pull request - Implements _pdf, pdf and get_max_density for each parameter type, as well as other support needed for PiBO

- Everything from PiBO PR1 and PR2
- _pdf and pdf
- get_max_density
- remove_parameter_priors with supporting static methods which copy forbiddens and conditions from the old (non-uniform) configspace to the new one
    - static method substitute_hyperparameters_in_conditions() 
    - static method substitute_hyperparameters_in_forbiddens()
- Accompanying tests
- Documentation in user guide
- Betaparameter pdfs now consider Unit hypercube scaling (plus skewing induced by Integer/quantization)
 