### PR TITLE
Add: Add forbidden relations between two hyperparameters

### DIFF
--- a/ConfigSpace/__init__.py
+++ b/ConfigSpace/__init__.py
@@ -42,7 +42,8 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
 from ConfigSpace.conditions import AndConjunction, OrConjunction, \
     EqualsCondition, NotEqualsCondition, InCondition, GreaterThanCondition, LessThanCondition
 from ConfigSpace.forbidden import ForbiddenAndConjunction, \
-    ForbiddenEqualsClause, ForbiddenInClause
+    ForbiddenEqualsClause, ForbiddenInClause, ForbiddenLessThan, ForbiddenEquals, \
+    ForbiddenGreaterThan
 
 __all__ = ["__version__", "Configuration", "ConfigurationSpace",
            "CategoricalHyperparameter", "UniformFloatHyperparameter",
@@ -52,4 +53,6 @@ __all__ = ["__version__", "Configuration", "ConfigurationSpace",
            "EqualsCondition", "NotEqualsCondition",
            "InCondition", "GreaterThanCondition",
            "LessThanCondition", "ForbiddenAndConjunction",
-           "ForbiddenEqualsClause", "ForbiddenInClause"]
+           "ForbiddenEqualsClause", "ForbiddenInClause",
+           "ForbiddenLessThan", "ForbiddenEquals",
+           "ForbiddenGreaterThan"]

--- a/ConfigSpace/__init__.py
+++ b/ConfigSpace/__init__.py
@@ -42,8 +42,8 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
 from ConfigSpace.conditions import AndConjunction, OrConjunction, \
     EqualsCondition, NotEqualsCondition, InCondition, GreaterThanCondition, LessThanCondition
 from ConfigSpace.forbidden import ForbiddenAndConjunction, \
-    ForbiddenEqualsClause, ForbiddenInClause, ForbiddenLessThan, ForbiddenEquals, \
-    ForbiddenGreaterThan
+    ForbiddenEqualsClause, ForbiddenInClause, ForbiddenLessThanRelation, ForbiddenEqualsRelation, \
+    ForbiddenGreaterThanRelation
 
 __all__ = ["__version__", "Configuration", "ConfigurationSpace",
            "CategoricalHyperparameter", "UniformFloatHyperparameter",
@@ -54,5 +54,5 @@ __all__ = ["__version__", "Configuration", "ConfigurationSpace",
            "InCondition", "GreaterThanCondition",
            "LessThanCondition", "ForbiddenAndConjunction",
            "ForbiddenEqualsClause", "ForbiddenInClause",
-           "ForbiddenLessThan", "ForbiddenEquals",
-           "ForbiddenGreaterThan"]
+           "ForbiddenLessThanRelation", "ForbiddenEqualsRelation",
+           "ForbiddenGreaterThanRelation"]

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -575,7 +575,8 @@ cdef class ForbiddenRelation(AbstractForbiddenComponent):
             else:
                 return False
 
-        return self._is_forbidden_vector(self.left._transform(left), self.right._transform(right))
+        # Relation is always evaluated against actual value and not vector representation
+        return self._is_forbidden(self.left._transform(left), self.right._transform(right))
 
     cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right) except -1:
         pass
@@ -599,6 +600,12 @@ cdef class ForbiddenLessThanRelation(ForbiddenRelation):
     >>> forbidden_clause = CS.ForbiddenLessThanRelation(a, b)
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a < b
+
+    Note
+    ____
+    If the values of the both hyperparameters are not comparible
+    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison *not* their oridnal value.
 
     Parameters
     ----------
@@ -637,6 +644,12 @@ cdef class ForbiddenEqualsRelation(ForbiddenRelation):
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a == b
 
+    Note
+    ____
+    If the values of the both hyperparameters are not comparible
+    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison *not* their oridnal value.
+
     Parameters
     ----------
      left : :ref:`Hyperparameters`
@@ -673,6 +686,12 @@ cdef class ForbiddenGreaterThanRelation(ForbiddenRelation):
     >>> forbidden_clause = CS.ForbiddenGreaterThanRelation(a, b)
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a > b
+
+    Note
+    ____
+    If the values of the both hyperparameters are not comparible
+    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison *not* their oridnal value.
 
     Parameters
     ----------

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -602,10 +602,10 @@ cdef class ForbiddenLessThanRelation(ForbiddenRelation):
     Forbidden: a < b
 
     Note
-    ____
+    ----
     If the values of the both hyperparameters are not comparible
-    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
-    the actual values are used for comparison *not* their oridnal value.
+    (e.g. comparing int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison **not** their ordinal value.
 
     Parameters
     ----------
@@ -645,10 +645,10 @@ cdef class ForbiddenEqualsRelation(ForbiddenRelation):
     Forbidden: a == b
 
     Note
-    ____
+    ----
     If the values of the both hyperparameters are not comparible
-    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
-    the actual values are used for comparison *not* their oridnal value.
+    (e.g. comparing int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison **not** their ordinal value.
 
     Parameters
     ----------
@@ -688,10 +688,10 @@ cdef class ForbiddenGreaterThanRelation(ForbiddenRelation):
     Forbidden: a > b
 
     Note
-    ____
+    ----
     If the values of the both hyperparameters are not comparible
-    (e.g. comapring int and str), a TypeError is raised. For OrdinalHyperparameters
-    the actual values are used for comparison *not* their oridnal value.
+    (e.g. comparing int and str), a TypeError is raised. For OrdinalHyperparameters
+    the actual values are used for comparison **not** their ordinal value.
 
     Parameters
     ----------

--- a/ConfigSpace/forbidden.pyx
+++ b/ConfigSpace/forbidden.pyx
@@ -514,9 +514,7 @@ cdef class ForbiddenRelation(AbstractForbiddenComponent):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return False
-
-        return (self.left.name == other.left.name and
-                self.right.name == other.right.name)
+        return self.left == other.left and self.right == other.right
 
     def __copy__(self):
         return self.__class__(
@@ -552,7 +550,7 @@ cdef class ForbiddenRelation(AbstractForbiddenComponent):
 
         return self._is_forbidden(left, right)
 
-    cdef _is_forbidden(self, left, right):
+    cdef int _is_forbidden(self, left, right) except -1:
         pass
 
     cdef int c_is_forbidden_vector(self, np.ndarray instantiated_vector, int strict):
@@ -577,13 +575,13 @@ cdef class ForbiddenRelation(AbstractForbiddenComponent):
             else:
                 return False
 
-        return self._is_forbidden(self.left._transform(left), self.right._transform(right))
+        return self._is_forbidden_vector(self.left._transform(left), self.right._transform(right))
 
-    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right):
+    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right) except -1:
         pass
 
 
-cdef class ForbiddenLessThan(ForbiddenRelation):
+cdef class ForbiddenLessThanRelation(ForbiddenRelation):
     """
     A ForbiddenLessThan relation between two hyperparameters.
 
@@ -598,7 +596,7 @@ cdef class ForbiddenLessThan(ForbiddenRelation):
     >>> cs.add_hyperparameters([a, b])
     [a, Type: Categorical, Choices: {1, 2, 3}, Default: 1, b, Type: ...]
 
-    >>> forbidden_clause = CS.ForbiddenLessThan(a, b)
+    >>> forbidden_clause = CS.ForbiddenLessThanRelation(a, b)
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a < b
 
@@ -613,14 +611,14 @@ cdef class ForbiddenLessThan(ForbiddenRelation):
     def __repr__(self):
         return "Forbidden: %s < %s" % (self.left.name, self.right.name)
 
-    cdef _is_forbidden(self, left, right):
+    cdef int _is_forbidden(self, left, right) except -1:
         return left < right
 
-    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right):
+    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right) except -1:
         return left < right
 
 
-cdef class ForbiddenEquals(ForbiddenRelation):
+cdef class ForbiddenEqualsRelation(ForbiddenRelation):
     """
     A ForbiddenEquals relation between two hyperparameters.
 
@@ -635,7 +633,7 @@ cdef class ForbiddenEquals(ForbiddenRelation):
     >>> cs.add_hyperparameters([a, b])
     [a, Type: Categorical, Choices: {1, 2, 3}, Default: 1, b, Type: ...]
 
-    >>> forbidden_clause = CS.ForbiddenEquals(a, b)
+    >>> forbidden_clause = CS.ForbiddenEqualsRelation(a, b)
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a == b
 
@@ -650,14 +648,14 @@ cdef class ForbiddenEquals(ForbiddenRelation):
     def __repr__(self):
         return "Forbidden: %s == %s" % (self.left.name, self.right.name)
 
-    cdef _is_forbidden(self, left, right):
+    cdef int _is_forbidden(self, left, right) except -1:
         return left == right
 
-    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right):
+    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right) except -1:
         return left == right
 
 
-cdef class ForbiddenGreaterThan(ForbiddenRelation):
+cdef class ForbiddenGreaterThanRelation(ForbiddenRelation):
     """
     A ForbiddenGreaterThan relation between two hyperparameters.
 
@@ -672,7 +670,7 @@ cdef class ForbiddenGreaterThan(ForbiddenRelation):
     >>> cs.add_hyperparameters([a, b])
     [a, Type: Categorical, Choices: {1, 2, 3}, Default: 1, b, Type: ...]
 
-    >>> forbidden_clause = CS.ForbiddenGreaterThan(a, b)
+    >>> forbidden_clause = CS.ForbiddenGreaterThanRelation(a, b)
     >>> cs.add_forbidden_clause(forbidden_clause)
     Forbidden: a > b
 
@@ -687,8 +685,8 @@ cdef class ForbiddenGreaterThan(ForbiddenRelation):
     def __repr__(self):
         return "Forbidden: %s > %s" % (self.left.name, self.right.name)
 
-    cdef _is_forbidden(self, left, right):
+    cdef int _is_forbidden(self, left, right) except -1:
         return left > right
 
-    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right):
+    cdef int _is_forbidden_vector(self, DTYPE_t left, DTYPE_t right) except -1:
         return left > right

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -35,9 +35,9 @@ from ConfigSpace.forbidden import (
     ForbiddenInClause,
     AbstractForbiddenComponent,
     ForbiddenRelation,
-    ForbiddenLessThan,
-    ForbiddenEquals,
-    ForbiddenGreaterThan,
+    ForbiddenLessThanRelation,
+    ForbiddenEqualsRelation,
+    ForbiddenGreaterThanRelation,
 )
 
 
@@ -295,11 +295,11 @@ def _build_forbidden_and_conjunction(clause: ForbiddenAndConjunction) -> Dict:
 
 
 def _build_forbidden_relation(clause: ForbiddenRelation) -> Dict:
-    if isinstance(clause, ForbiddenLessThan):
+    if isinstance(clause, ForbiddenLessThanRelation):
         lambda_ = 'LESS'
-    elif isinstance(clause, ForbiddenEquals):
+    elif isinstance(clause, ForbiddenEqualsRelation):
         lambda_ = 'EQUALS'
-    elif isinstance(clause, ForbiddenGreaterThan):
+    elif isinstance(clause, ForbiddenGreaterThanRelation):
         lambda_ = 'GREATER'
     else:
         raise ValueError("Unknown relation '%s'" % type(clause))
@@ -673,11 +673,11 @@ def _construct_forbidden_relation(
     right = cs.get_hyperparameter(clause['right'])
 
     if clause['lambda'] == "LESS":
-        return ForbiddenLessThan(left, right)
+        return ForbiddenLessThanRelation(left, right)
     elif clause['lambda'] == "EQUALS":
-        return ForbiddenEquals(left, right)
+        return ForbiddenEqualsRelation(left, right)
     elif clause['lambda'] == "GREATER":
-        return ForbiddenGreaterThan(left, right)
+        return ForbiddenGreaterThanRelation(left, right)
     else:
         raise ValueError("Unknown relation '%s'" % clause['lambda'])
 

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -34,10 +34,14 @@ from ConfigSpace.forbidden import (
     ForbiddenAndConjunction,
     ForbiddenInClause,
     AbstractForbiddenComponent,
+    ForbiddenRelation,
+    ForbiddenLessThan,
+    ForbiddenEquals,
+    ForbiddenGreaterThan,
 )
 
 
-JSON_FORMAT_VERSION = 0.3
+JSON_FORMAT_VERSION = 0.4
 
 
 ################################################################################
@@ -257,6 +261,8 @@ def _build_forbidden(clause) -> Dict:
         return _build_forbidden_in_clause(clause)
     elif isinstance(clause, ForbiddenAndConjunction):
         return _build_forbidden_and_conjunction(clause)
+    elif isinstance(clause, ForbiddenRelation):
+        return _build_forbidden_relation(clause)
     else:
         raise TypeError(clause)
 
@@ -285,6 +291,24 @@ def _build_forbidden_and_conjunction(clause: ForbiddenAndConjunction) -> Dict:
         'clauses': [
             _build_forbidden(component) for component in clause.components
         ],
+    }
+
+
+def _build_forbidden_relation(clause: ForbiddenRelation) -> Dict:
+    if isinstance(clause, ForbiddenLessThan):
+        lambda_ = 'LESS'
+    elif isinstance(clause, ForbiddenEquals):
+        lambda_ = 'EQUALS'
+    elif isinstance(clause, ForbiddenGreaterThan):
+        lambda_ = 'GREATER'
+    else:
+        raise ValueError("Unknown relation '%s'" % type(clause))
+
+    return {
+        'left': clause.left.name,
+        'right': clause.right.name,
+        'type': 'RELATION',
+        'lambda': lambda_
     }
 
 
@@ -607,6 +631,8 @@ def _construct_forbidden(
         return _construct_forbidden_in(clause, cs)
     elif forbidden_type == 'AND':
         return _construct_forbidden_and(clause, cs)
+    elif forbidden_type == 'RELATION':
+        return _construct_forbidden_equals(clause, cs)
     else:
         return ValueError(forbidden_type)
 
@@ -637,3 +663,21 @@ def _construct_forbidden_and(
 ) -> ForbiddenAndConjunction:
     clauses = [_construct_forbidden(cl, cs) for cl in clause['clauses']]
     return ForbiddenAndConjunction(*clauses)
+
+
+def _construct_forbidden_relation(
+        clause: Dict,
+        cs: ConfigurationSpace,
+) -> ForbiddenRelation:
+    left = cs.get_hyperparameter(clause['left'])
+    right = cs.get_hyperparameter(clause['right'])
+
+    if clause['lambda'] == "LESS":
+        return ForbiddenLessThan(left, right)
+    elif clause['lambda'] == "EQUALS":
+        return ForbiddenEquals(left, right)
+    elif clause['lambda'] == "GREATER":
+        return ForbiddenGreaterThan(left, right)
+    else:
+        raise ValueError("Unknown relation '%s'" % clause['lambda'])
+

--- a/ConfigSpace/read_and_write/json.py
+++ b/ConfigSpace/read_and_write/json.py
@@ -680,4 +680,3 @@ def _construct_forbidden_relation(
         return ForbiddenGreaterThanRelation(left, right)
     else:
         raise ValueError("Unknown relation '%s'" % clause['lambda'])
-

--- a/ConfigSpace/read_and_write/pcs_new.py
+++ b/ConfigSpace/read_and_write/pcs_new.py
@@ -58,6 +58,7 @@ from ConfigSpace.forbidden import (
     ForbiddenInClause,
     AbstractForbiddenComponent,
     MultipleValueForbiddenClause,
+    ForbiddenRelation,
 )
 
 # Build pyparsing expressions for params
@@ -216,6 +217,10 @@ def build_forbidden(clause):
         raise TypeError("build_forbidden must be called with an instance of "
                         "'%s', got '%s'" %
                         (AbstractForbiddenComponent, type(clause)))
+    if isinstance(clause, ForbiddenRelation):
+        raise TypeError("build_forbidden must not be called with an instance of "
+                        "'%s', got '%s'" %
+                        (ForbiddenRelation, type(clause)))
 
     retval = StringIO()
     retval.write("{")

--- a/test/read_and_write/test_json.py
+++ b/test/read_and_write/test_json.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from ConfigSpace.forbidden import ForbiddenLessThan
+from ConfigSpace.forbidden import ForbiddenLessThanRelation
 from ConfigSpace.read_and_write.json import read, write
 from ConfigSpace.read_and_write.pcs import read as read_pcs
 from ConfigSpace.read_and_write.pcs_new import read as read_pcs_new
@@ -24,7 +24,7 @@ class TestJson(unittest.TestCase):
         cs = ConfigurationSpace()
         a = cs.add_hyperparameter(CategoricalHyperparameter('a', [0, 1, 2]))
         b = cs.add_hyperparameter(CategoricalHyperparameter('b', [0, 1, 2]))
-        cs.add_forbidden_clause(ForbiddenLessThan(a, b))
+        cs.add_forbidden_clause(ForbiddenLessThanRelation(a, b))
         write(cs)
 
     def test_configspace_with_probabilities(self):

--- a/test/read_and_write/test_json.py
+++ b/test/read_and_write/test_json.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from ConfigSpace.forbidden import ForbiddenLessThan
 from ConfigSpace.read_and_write.json import read, write
 from ConfigSpace.read_and_write.pcs import read as read_pcs
 from ConfigSpace.read_and_write.pcs_new import read as read_pcs_new
@@ -17,6 +18,13 @@ class TestJson(unittest.TestCase):
         cs = ConfigurationSpace()
         a = cs.add_hyperparameter(CategoricalHyperparameter('a', [0, 1, 2]))
         cs.add_forbidden_clause(ForbiddenInClause(a, [1, 2]))
+        write(cs)
+
+    def test_serialize_forbidden_relation(self):
+        cs = ConfigurationSpace()
+        a = cs.add_hyperparameter(CategoricalHyperparameter('a', [0, 1, 2]))
+        b = cs.add_hyperparameter(CategoricalHyperparameter('b', [0, 1, 2]))
+        cs.add_forbidden_clause(ForbiddenLessThan(a, b))
         write(cs)
 
     def test_configspace_with_probabilities(self):

--- a/test/read_and_write/test_pcs_converter.py
+++ b/test/read_and_write/test_pcs_converter.py
@@ -39,8 +39,12 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
 from ConfigSpace.conditions import EqualsCondition, InCondition, \
     AndConjunction, OrConjunction, NotEqualsCondition, \
     GreaterThanCondition
-from ConfigSpace.forbidden import ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsClause, \
-    ForbiddenGreaterThanRelation
+from ConfigSpace.forbidden import (
+    ForbiddenInClause,
+    ForbiddenAndConjunction,
+    ForbiddenEqualsClause,
+    ForbiddenGreaterThanRelation,
+)
 
 # More complex search space
 classifier = CategoricalHyperparameter("classifier", ["svm", "nn"])

--- a/test/read_and_write/test_pcs_converter.py
+++ b/test/read_and_write/test_pcs_converter.py
@@ -39,7 +39,8 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
 from ConfigSpace.conditions import EqualsCondition, InCondition, \
     AndConjunction, OrConjunction, NotEqualsCondition, \
     GreaterThanCondition
-from ConfigSpace.forbidden import ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsClause
+from ConfigSpace.forbidden import ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsClause, \
+    ForbiddenGreaterThanRelation
 
 # More complex search space
 classifier = CategoricalHyperparameter("classifier", ["svm", "nn"])
@@ -431,6 +432,17 @@ class TestPCSConverter(unittest.TestCase):
         cs_new = pcs_new.read(complex_cs)
 
         self.assertEqual(cs_new, cs_with_forbidden)
+
+    def test_write_new_configuration_space_forbidden_relation(self):
+        cs_with_forbidden = ConfigurationSpace()
+        int_hp = UniformIntegerHyperparameter('int_hp', 0, 50, 30)
+        float_hp = UniformFloatHyperparameter('float_hp', 0., 50., 30.)
+
+        forbidden = ForbiddenGreaterThanRelation(int_hp, float_hp)
+        cs_with_forbidden.add_hyperparameters([int_hp, float_hp])
+        cs_with_forbidden.add_forbidden_clause(forbidden)
+
+        self.assertRaises(TypeError, pcs_new.write, {'configuration_space': cs_with_forbidden})
 
     def test_read_new_configuration_space_complex_conditionals(self):
         classi = OrdinalHyperparameter(

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -235,6 +235,14 @@ class TestConfigurationSpace(unittest.TestCase):
                                   "  Forbidden Clauses:\n"
                                   "    Forbidden: input1 == input2\n")
 
+    def test_add_forbidden_relation_categorical(self):
+        cs = ConfigurationSpace()
+        hp1 = CategoricalHyperparameter("input1", ['a', 'b'], default_value='b')
+        hp2 = CategoricalHyperparameter("input2", ['b', 'c'], default_value='b')
+        cs.add_hyperparameters([hp1, hp2])
+        forb = ForbiddenEqualsRelation(hp1, hp2)
+        self.assertRaises(ForbiddenValueError, cs.add_forbidden_clause, forb)
+
     def test_add_forbidden_illegal(self):
         cs = ConfigurationSpace()
         hp = CategoricalHyperparameter("input1", [0, 1])

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -46,7 +46,7 @@ from ConfigSpace.hyperparameters import (UniformFloatHyperparameter,
                                          BetaIntegerHyperparameter,
                                          OrdinalHyperparameter)
 from ConfigSpace.exceptions import ForbiddenValueError
-from ConfigSpace.forbidden import ForbiddenEquals
+from ConfigSpace.forbidden import ForbiddenEqualsRelation
 
 
 def byteify(input):
@@ -224,7 +224,7 @@ class TestConfigurationSpace(unittest.TestCase):
         hp1 = CategoricalHyperparameter("input1", [0, 1])
         hp2 = CategoricalHyperparameter("input2", [1, 0])
         cs.add_hyperparameters([hp1, hp2])
-        forb = ForbiddenEquals(hp1, hp2)
+        forb = ForbiddenEqualsRelation(hp1, hp2)
         # TODO add checking whether a forbidden clause makes sense at all
         cs.add_forbidden_clause(forb)
         # TODO add something to properly retrieve the forbidden clauses

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -46,6 +46,7 @@ from ConfigSpace.hyperparameters import (UniformFloatHyperparameter,
                                          BetaIntegerHyperparameter,
                                          OrdinalHyperparameter)
 from ConfigSpace.exceptions import ForbiddenValueError
+from ConfigSpace.forbidden import ForbiddenEquals
 
 
 def byteify(input):
@@ -217,6 +218,22 @@ class TestConfigurationSpace(unittest.TestCase):
                                   "Default: 0\n"
                                   "  Forbidden Clauses:\n"
                                   "    Forbidden: input1 == 1\n")
+
+    def test_add_forbidden_relation(self):
+        cs = ConfigurationSpace()
+        hp1 = CategoricalHyperparameter("input1", [0, 1])
+        hp2 = CategoricalHyperparameter("input2", [1, 0])
+        cs.add_hyperparameters([hp1, hp2])
+        forb = ForbiddenEquals(hp1, hp2)
+        # TODO add checking whether a forbidden clause makes sense at all
+        cs.add_forbidden_clause(forb)
+        # TODO add something to properly retrieve the forbidden clauses
+        self.assertEqual(str(cs), "Configuration space object:\n  "
+                                  "Hyperparameters:\n"
+                                  "    input1, Type: Categorical, Choices: {0, 1}, Default: 0\n"
+                                  "    input2, Type: Categorical, Choices: {1, 0}, Default: 1\n"
+                                  "  Forbidden Clauses:\n"
+                                  "    Forbidden: input1 == input2\n")
 
     def test_add_forbidden_illegal(self):
         cs = ConfigurationSpace()

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -280,3 +280,9 @@ class TestForbidden(unittest.TestCase):
         forb3 = ForbiddenEqualsRelation(hp3, hp4)
         self.assertTrue(forb1 == forb2)
         self.assertFalse(forb2 == forb3)
+
+        hp1 = OrdinalHyperparameter("water_temperature", ["cold", "luke-warm", "hot", "boiling"])
+        hp2 = OrdinalHyperparameter("water_temperature2", ["cold", "luke-warm", "hot", "boiling"])
+        forb = ForbiddenGreaterThanRelation(hp1, hp2)
+        self.assertFalse(forb.is_forbidden({'water_temperature': 'boiling', 'water_temperature2': 'cold'}, True))
+        self.assertTrue(forb.is_forbidden({'water_temperature': 'hot', 'water_temperature2': 'cold'}, True))

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -37,7 +37,7 @@ from ConfigSpace.hyperparameters import \
 # from ConfigSpace.forbidden import ForbiddenEqualsClause, \
 #     ForbiddenInClause, ForbiddenAndConjunction
 from ConfigSpace.forbidden import ForbiddenEqualsClause, \
-    ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEquals, ForbiddenLessThan, ForbiddenGreaterThan
+    ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsRelation, ForbiddenLessThanRelation, ForbiddenGreaterThanRelation
 
 
 class TestForbidden(unittest.TestCase):
@@ -233,28 +233,34 @@ class TestForbidden(unittest.TestCase):
         hp4 = UniformFloatHyperparameter("float", 0, 2)
         hp5 = CategoricalHyperparameter("str", ['foo', 'bar'])
 
-        forb = ForbiddenEquals(hp1, hp2)
+        forb = ForbiddenEqualsRelation(hp1, hp2)
         self.assertTrue(forb.is_forbidden({'cat_int': 1, 'int': 1}, True))
         self.assertFalse(forb.is_forbidden({'cat_int': 0, 'int': 1}, True))
 
-        forb = ForbiddenEquals(hp2, hp3)
+        forb = ForbiddenEqualsRelation(hp2, hp3)
         self.assertTrue(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 0}, True))
 
-        forb = ForbiddenLessThan(hp2, hp3)
+        forb = ForbiddenLessThanRelation(hp2, hp3)
         self.assertTrue(forb.is_forbidden({'int': 0, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 0}, True))
 
-        forb = ForbiddenGreaterThan(hp2, hp3)
+        forb = ForbiddenGreaterThanRelation(hp2, hp3)
         self.assertTrue(forb.is_forbidden({'int': 1, 'int2': 0}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 0, 'int2': 1}, True))
 
-        forb = ForbiddenGreaterThan(hp3, hp4)
+        forb = ForbiddenGreaterThanRelation(hp3, hp4)
         self.assertTrue(forb.is_forbidden({'int2': 1, 'float': 0}, True))
         self.assertFalse(forb.is_forbidden({'int2': 1, 'float': 1}, True))
         self.assertFalse(forb.is_forbidden({'int2': 0, 'float': 1}, True))
 
-        forb = ForbiddenGreaterThan(hp4, hp5)
+        forb = ForbiddenGreaterThanRelation(hp4, hp5)
         self.assertRaises(TypeError, forb.is_forbidden, {'float': 1, 'str': 'foo'}, True)
+
+        forb1 = ForbiddenEqualsRelation(hp1, hp2)
+        forb2 = ForbiddenEqualsRelation(hp1, hp2)
+        forb3 = ForbiddenEqualsRelation(hp2, hp3)
+        self.assertTrue(forb1 == forb2)
+        self.assertFalse(forb2 == forb3)

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -36,9 +36,14 @@ from ConfigSpace.hyperparameters import \
 
 # from ConfigSpace.forbidden import ForbiddenEqualsClause, \
 #     ForbiddenInClause, ForbiddenAndConjunction
-from ConfigSpace.forbidden import ForbiddenEqualsClause, \
-    ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsRelation, ForbiddenLessThanRelation, \
-    ForbiddenGreaterThanRelation
+from ConfigSpace.forbidden import (
+    ForbiddenEqualsClause,
+    ForbiddenInClause,
+    ForbiddenAndConjunction,
+    ForbiddenEqualsRelation,
+    ForbiddenLessThanRelation,
+    ForbiddenGreaterThanRelation,
+)
 
 from ConfigSpace import OrdinalHyperparameter
 
@@ -284,5 +289,11 @@ class TestForbidden(unittest.TestCase):
         hp1 = OrdinalHyperparameter("water_temperature", ["cold", "luke-warm", "hot", "boiling"])
         hp2 = OrdinalHyperparameter("water_temperature2", ["cold", "luke-warm", "hot", "boiling"])
         forb = ForbiddenGreaterThanRelation(hp1, hp2)
-        self.assertFalse(forb.is_forbidden({'water_temperature': 'boiling', 'water_temperature2': 'cold'}, True))
-        self.assertTrue(forb.is_forbidden({'water_temperature': 'hot', 'water_temperature2': 'cold'}, True))
+        self.assertFalse(forb.is_forbidden(
+            {'water_temperature': 'boiling', 'water_temperature2': 'cold'},
+            True)
+        )
+        self.assertTrue(forb.is_forbidden(
+            {'water_temperature': 'hot', 'water_temperature2': 'cold'},
+            True)
+        )

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -37,7 +37,10 @@ from ConfigSpace.hyperparameters import \
 # from ConfigSpace.forbidden import ForbiddenEqualsClause, \
 #     ForbiddenInClause, ForbiddenAndConjunction
 from ConfigSpace.forbidden import ForbiddenEqualsClause, \
-    ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsRelation, ForbiddenLessThanRelation, ForbiddenGreaterThanRelation
+    ForbiddenInClause, ForbiddenAndConjunction, ForbiddenEqualsRelation, ForbiddenLessThanRelation, \
+    ForbiddenGreaterThanRelation
+
+from ConfigSpace import OrdinalHyperparameter
 
 
 class TestForbidden(unittest.TestCase):
@@ -228,39 +231,52 @@ class TestForbidden(unittest.TestCase):
 
     def test_relation(self):
         hp1 = CategoricalHyperparameter("cat_int", [0, 1])
-        hp2 = UniformIntegerHyperparameter("int", 0, 2)
-        hp3 = UniformIntegerHyperparameter("int2", 0, 2)
-        hp4 = UniformFloatHyperparameter("float", 0, 2)
-        hp5 = CategoricalHyperparameter("str", ['foo', 'bar'])
+        hp2 = OrdinalHyperparameter("ord_int", [0, 1])
+        hp3 = UniformIntegerHyperparameter("int", 0, 2)
+        hp4 = UniformIntegerHyperparameter("int2", 0, 2)
+        hp5 = UniformFloatHyperparameter("float", 0, 2)
+        hp6 = CategoricalHyperparameter("str", ['a', 'b'])
+        hp7 = CategoricalHyperparameter("str2", ['b', 'c'])
 
         forb = ForbiddenEqualsRelation(hp1, hp2)
+        self.assertTrue(forb.is_forbidden({'cat_int': 1, 'ord_int': 1}, True))
+        self.assertFalse(forb.is_forbidden({'cat_int': 0, 'ord_int': 1}, True))
+
+        forb = ForbiddenEqualsRelation(hp1, hp3)
         self.assertTrue(forb.is_forbidden({'cat_int': 1, 'int': 1}, True))
         self.assertFalse(forb.is_forbidden({'cat_int': 0, 'int': 1}, True))
 
-        forb = ForbiddenEqualsRelation(hp2, hp3)
+        forb = ForbiddenEqualsRelation(hp3, hp4)
         self.assertTrue(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 0}, True))
 
-        forb = ForbiddenLessThanRelation(hp2, hp3)
+        forb = ForbiddenLessThanRelation(hp3, hp4)
         self.assertTrue(forb.is_forbidden({'int': 0, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 0}, True))
 
-        forb = ForbiddenGreaterThanRelation(hp2, hp3)
+        forb = ForbiddenGreaterThanRelation(hp3, hp4)
         self.assertTrue(forb.is_forbidden({'int': 1, 'int2': 0}, True))
         self.assertFalse(forb.is_forbidden({'int': 1, 'int2': 1}, True))
         self.assertFalse(forb.is_forbidden({'int': 0, 'int2': 1}, True))
 
-        forb = ForbiddenGreaterThanRelation(hp3, hp4)
+        forb = ForbiddenGreaterThanRelation(hp4, hp5)
         self.assertTrue(forb.is_forbidden({'int2': 1, 'float': 0}, True))
         self.assertFalse(forb.is_forbidden({'int2': 1, 'float': 1}, True))
         self.assertFalse(forb.is_forbidden({'int2': 0, 'float': 1}, True))
 
-        forb = ForbiddenGreaterThanRelation(hp4, hp5)
-        self.assertRaises(TypeError, forb.is_forbidden, {'float': 1, 'str': 'foo'}, True)
+        forb = ForbiddenGreaterThanRelation(hp5, hp6)
+        self.assertRaises(TypeError, forb.is_forbidden, {'float': 1, 'str': 'b'}, True)
 
-        forb1 = ForbiddenEqualsRelation(hp1, hp2)
-        forb2 = ForbiddenEqualsRelation(hp1, hp2)
-        forb3 = ForbiddenEqualsRelation(hp2, hp3)
+        forb = ForbiddenGreaterThanRelation(hp5, hp7)
+        self.assertRaises(TypeError, forb.is_forbidden, {'float': 1, 'str2': 'b'}, True)
+
+        forb = ForbiddenGreaterThanRelation(hp6, hp7)
+        self.assertTrue(forb.is_forbidden({'str': 'b', 'str2': 'a'}, True))
+        self.assertTrue(forb.is_forbidden({'str': 'c', 'str2': 'a'}, True))
+
+        forb1 = ForbiddenEqualsRelation(hp2, hp3)
+        forb2 = ForbiddenEqualsRelation(hp2, hp3)
+        forb3 = ForbiddenEqualsRelation(hp3, hp4)
         self.assertTrue(forb1 == forb2)
         self.assertFalse(forb2 == forb3)


### PR DESCRIPTION
Add forbidden relations between two hyperparameters. It is possible to define less than, equals and greater than relations.

This PR solves #198.

I am not sure about necessary adaption for `read_write.pcs`, I would be great if you could give me a pointer how to implement that correctly. If I forgot some other place, please just let me know.

Short disclaimer: I haven't written python extensions for a long time, please be careful checking that I didn't mess up...