### PR TITLE
Fix small bugs related to nan values in vector passed to pdf

### DIFF
--- a/ConfigSpace/configuration_space.pyx
+++ b/ConfigSpace/configuration_space.pyx
@@ -1526,12 +1526,12 @@ class ConfigurationSpace(collections.abc.Mapping):
                 new_child = new_configspace[child_name]
                 new_parent = new_configspace[parent_name]
 
-                if hasattr(condition, 'value'):
-                    condition_arg = getattr(condition, 'value')
-                    substituted_condition = condition_type(child=new_child, parent=new_parent, value=condition_arg)
-                elif hasattr(condition, 'values'):
+                if hasattr(condition, 'values'):
                     condition_arg = getattr(condition, 'values')
                     substituted_condition = condition_type(child=new_child, parent=new_parent, values=condition_arg)
+                elif hasattr(condition, 'value'):
+                    condition_arg = getattr(condition, 'value')
+                    substituted_condition = condition_type(child=new_child, parent=new_parent, value=condition_arg)
                 else:
                     raise AttributeError(f'Did not find the expected attribute in condition {type(condition)}.')
 
@@ -1573,15 +1573,24 @@ class ConfigurationSpace(collections.abc.Mapping):
                 hyperparameter_name = getattr(forbidden.hyperparameter, 'name')
                 new_hyperparameter = new_configspace[hyperparameter_name]
 
-                if hasattr(forbidden, 'value'):
-                    forbidden_arg = getattr(forbidden, 'value')
-                    substituted_forbidden = forbidden_type(hyperparameter=new_hyperparameter, value=forbidden_arg)
-                elif hasattr(forbidden, 'values'):
+                if hasattr(forbidden, 'values'):
                     forbidden_arg = getattr(forbidden, 'values')
                     substituted_forbidden = forbidden_type(hyperparameter=new_hyperparameter, values=forbidden_arg)
+                elif hasattr(forbidden, 'value'):
+                    forbidden_arg = getattr(forbidden, 'value')
+                    substituted_forbidden = forbidden_type(hyperparameter=new_hyperparameter, value=forbidden_arg)
                 else:
                     raise AttributeError(f'Did not find the expected attribute in forbidden {type(forbidden)}.')
 
+                new_forbiddens.append(substituted_forbidden)
+            elif isinstance(forbidden, ForbiddenRelation):
+                forbidden_type = type(forbidden)
+                left_name = getattr(forbidden.left, 'name')
+                left_hyperparameter = new_configspace[left_name]
+                right_name = getattr(forbidden.right, 'name')
+                right_hyperparameter = new_configspace[right_name]
+
+                substituted_forbidden = forbidden_type(left=left_hyperparameter, right=right_hyperparameter)
                 new_forbiddens.append(substituted_forbidden)
             else:
                 raise TypeError(f'Did not expect the supplied forbidden type {type(forbidden)}.')

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -2609,7 +2609,13 @@ cdef class CategoricalHyperparameter(Hyperparameter):
             Probability density values of the input vector
         """
         probs = np.array(self.probabilities)
+        nan = np.isnan(vector)
+        if np.any(nan):
+            # Temporarily pick any valid index to use `vector` as an index for `probs`
+            vector[nan] = 0
         res = np.array(probs[vector.astype(int)])
+        if np.any(nan):
+            res[nan] = 0
         if res.ndim == 0:
             return res.reshape(-1)
         return res

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1945,6 +1945,7 @@ class TestHyperparameters(unittest.TestCase):
         point_1 = np.array([0])
         point_2 = np.array([1])
         array_1 = np.array([1, 0, 2])
+        nan = np.array([0, np.nan])
         self.assertEqual(c1._pdf(point_1)[0], 0.4)
         self.assertEqual(c1._pdf(point_2)[0], 0.2)
         self.assertAlmostEqual(c2._pdf(point_1)[0], 0.7142857142857143)
@@ -1956,6 +1957,12 @@ class TestHyperparameters(unittest.TestCase):
         for res, exp_res in zip(array_results, expected_results):
             self.assertEqual(res, exp_res)
 
+        nan_results = c1._pdf(nan)
+        expected_results = np.array([0.4, 0])
+        self.assertEqual(nan_results.shape, expected_results.shape)
+        for res, exp_res in zip(nan_results, expected_results):
+            self.assertEqual(res, exp_res)
+
         # pdf must take a numpy array
         with self.assertRaises(TypeError):
             c1._pdf(0.2)
@@ -1963,7 +1970,7 @@ class TestHyperparameters(unittest.TestCase):
             c1._pdf('pdf')
         with self.assertRaises(TypeError):
             c1._pdf('one')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             c1._pdf(np.array(['zero']))
 
     def test_categorical_get_max_density(self):


### PR DESCRIPTION
I tried to incorporate the new prior system with SMAC and noticed some bugs regarding NaN values introduced by conditional hyperparameters. This PR resolves all issues I have encountered with conditional hyperparameters.

If you would like to, I can also provide a minimal working example showcasing the current problems.