### PR TITLE
Fix np.__round__ does not exist

### DIFF
--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1143,7 +1143,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         mu = self.mu
         sigma = self.sigma
         if self.lower == None:
-            return norm(loc=mu, scale=sigma).pdf(vector.astype(float))
+            return norm(loc=mu, scale=sigma).pdf(vector)
         else:
             mu = self.mu
             sigma = self.sigma
@@ -1152,7 +1152,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             a = (lower - mu) / sigma
             b = (upper - mu) / sigma
             
-            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector.astype(float))
+            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
 
     def get_max_density(self) -> float:
         if self.lower is None:

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -1143,7 +1143,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         mu = self.mu
         sigma = self.sigma
         if self.lower == None:
-            return norm(loc=mu, scale=sigma).pdf(vector)
+            return norm(loc=mu, scale=sigma).pdf(vector.astype(float))
         else:
             mu = self.mu
             sigma = self.sigma
@@ -1152,7 +1152,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
             a = (lower - mu) / sigma
             b = (upper - mu) / sigma
             
-            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector)
+            return truncnorm(a, b, loc=mu, scale=sigma).pdf(vector.astype(float))
 
     def get_max_density(self) -> float:
         if self.lower is None:

--- a/ConfigSpace/hyperparameters.pyx
+++ b/ConfigSpace/hyperparameters.pyx
@@ -777,7 +777,7 @@ cdef class UniformFloatHyperparameter(FloatHyperparameter):
         if self.log:
             scalar = math.exp(scalar)
         if self.q is not None:
-            scalar = round((scalar - self.lower) / self.q) * self.q + self.lower
+            scalar = np.round((scalar - self.lower) / self.q) * self.q + self.lower
             scalar = min(scalar, self.upper)
             scalar = max(scalar, self.lower)
         scalar = min(self.upper, max(self.lower, scalar))
@@ -1090,7 +1090,7 @@ cdef class NormalFloatHyperparameter(FloatHyperparameter):
         if self.log:
             scalar = math.exp(scalar)
         if self.q is not None:
-            scalar = round(scalar / self.q) * self.q
+            scalar = np.round(scalar / self.q) * self.q
         return scalar
 
     def _inverse_transform(self, vector: Optional[np.ndarray]) -> Union[float, np.ndarray]:
@@ -1512,10 +1512,10 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
     cpdef long long _transform_scalar(self, double scalar):
         scalar = self.ufhp._transform_scalar(scalar)
         if self.q is not None:
-            scalar = round((scalar - self.lower) / self.q) * self.q + self.lower
+            scalar = np.round((scalar - self.lower) / self.q) * self.q + self.lower
             scalar = min(scalar, self.upper)
             scalar = max(scalar, self.lower)
-        return int(round(scalar))
+        return int(np.round(scalar))
 
     def _inverse_transform(self, vector: Union[np.ndarray, float, int]
                            ) -> Union[np.ndarray, float, int]:
@@ -1898,7 +1898,7 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
 
     cpdef long long _transform_scalar(self, double scalar):
         scalar = self.nfhp._transform_scalar(scalar)
-        return int(round(scalar))
+        return int(np.round(scalar))
 
     def _inverse_transform(self, vector: Union[np.ndarray, float, int]
                            ) -> Union[np.ndarray, float]:
@@ -2048,7 +2048,7 @@ cdef class BetaIntegerHyperparameter(UniformIntegerHyperparameter):
 
         """
         super(BetaIntegerHyperparameter, self).__init__(
-            name, lower, upper, round((upper + lower) / 2), q, log, meta)
+            name, lower, upper, np.round((upper + lower) / 2), q, log, meta)
         self.alpha = float(alpha)
         self.beta = float(beta)
         if (alpha < 1) or (beta < 1):

--- a/ConfigSpace/util.pyx
+++ b/ConfigSpace/util.pyx
@@ -563,7 +563,7 @@ def generate_grid(configuration_space: ConfigurationSpace,
 
             if param.log:
                 grid_points = np.exp(grid_points)
-            grid_points = grid_points.astype(int)
+            grid_points = np.round(grid_points)
 
             # Avoiding rounding off issues
             if grid_points[0] < param.lower:

--- a/ConfigSpace/util.pyx
+++ b/ConfigSpace/util.pyx
@@ -563,7 +563,7 @@ def generate_grid(configuration_space: ConfigurationSpace,
 
             if param.log:
                 grid_points = np.exp(grid_points)
-            grid_points = np.round(grid_points)
+            grid_points = np.round(grid_points).astype(int)
 
             # Avoiding rounding off issues
             if grid_points[0] < param.lower:

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1484,7 +1484,7 @@ class TestHyperparameters(unittest.TestCase):
 
         # This should yield a value that's approximately halfway towards the max in logspace
         f_symm_log = BetaIntegerHyperparameter(
-            "param", lower=1, upper=round(np.exp(10)), alpha=4.6, beta=4.6, log=True)
+            "param", lower=1, upper=np.round(np.exp(10)), alpha=4.6, beta=4.6, log=True)
         self.assertAlmostEqual(f_symm_log.default_value, 148)
         self.assertAlmostEqual(f_symm_log.normalized_default_value, 0.5321491582577761)
 
@@ -1495,7 +1495,7 @@ class TestHyperparameters(unittest.TestCase):
 
         # This should yield a value that's halfway towards the max in logspace
         f_unif_log = BetaIntegerHyperparameter(
-            "param", lower=1, upper=round(np.exp(10)), alpha=1, beta=1, log=True)
+            "param", lower=1, upper=np.round(np.exp(10)), alpha=1, beta=1, log=True)
         self.assertAlmostEqual(f_unif_log.default_value, 148)
         self.assertAlmostEqual(f_unif_log.normalized_default_value, 0.5321491582577761)
 
@@ -1506,7 +1506,7 @@ class TestHyperparameters(unittest.TestCase):
         self.assertAlmostEqual(f_max.normalized_default_value, 0.7, places=4)
 
         f_max_log = BetaIntegerHyperparameter(
-            "param", lower=1, upper=round(np.exp(10)), alpha=4.7, beta=2.12, log=True)
+            "param", lower=1, upper=np.round(np.exp(10)), alpha=4.7, beta=2.12, log=True)
         self.assertAlmostEqual(f_max_log.default_value, 2157)
         self.assertAlmostEqual(f_max_log.normalized_default_value, 0.7827083200774537)
 
@@ -1646,7 +1646,7 @@ class TestHyperparameters(unittest.TestCase):
     def test_betaint__pdf(self):
         c1 = BetaIntegerHyperparameter("param", alpha=3, beta=2, lower=0, upper=10)
         c2 = BetaIntegerHyperparameter("logparam", alpha=3, beta=2,
-                                       lower=1, upper=round(np.exp(10)), log=True)
+                                       lower=1, upper=np.round(np.exp(10)), log=True)
 
         # since the logged and unlogged parameters will have different active domains
         # in the unit range, they will not evaluate identically under _pdf

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -599,7 +599,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -655,7 +655,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
 
         # Simply check that it runs, since _pdf does not restrict shape (only public method does)
         c1._pdf(accepted_shape_1)
@@ -1352,7 +1352,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -1400,7 +1400,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
 
     def test_normalint_get_max_density(self):
         c1 = NormalIntegerHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -599,7 +599,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2]))[0], 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -655,7 +655,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2]))[0], 0.17603266338214976)
 
         # Simply check that it runs, since _pdf does not restrict shape (only public method does)
         c1._pdf(accepted_shape_1)
@@ -1400,7 +1400,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2]))[0], 0.17603266338214976)
 
     def test_normalint_get_max_density(self):
         c1 = NormalIntegerHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -599,7 +599,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -655,7 +655,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
 
         # Simply check that it runs, since _pdf does not restrict shape (only public method does)
         c1._pdf(accepted_shape_1)
@@ -1352,7 +1352,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2]))[0], 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -1400,7 +1400,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])[0]), 0.17603266338214976)
 
     def test_normalint_get_max_density(self):
         c1 = NormalIntegerHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -599,7 +599,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -655,7 +655,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
 
         # Simply check that it runs, since _pdf does not restrict shape (only public method does)
         c1._pdf(accepted_shape_1)
@@ -1352,7 +1352,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
 
         with self.assertRaisesRegex(ValueError, "Method pdf expects a one-dimensional numpy array"):
             c1.pdf(wrong_shape_1)
@@ -1400,7 +1400,7 @@ class TestHyperparameters(unittest.TestCase):
             c1.pdf('pdf')
 
         c_nobounds = NormalFloatHyperparameter("param", mu=3, sigma=2)
-        self.assertAlmostEqual(c_nobounds.pdf(np.array([[2]])), 0.17603266338214976)
+        self.assertAlmostEqual(c_nobounds.pdf(np.array([2])), 0.17603266338214976)
 
     def test_normalint_get_max_density(self):
         c1 = NormalIntegerHyperparameter("param", lower=0, upper=10, mu=3, sigma=2)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -28,6 +28,7 @@
 
 import os
 import unittest
+from pytest import approx
 
 import numpy as np
 
@@ -491,8 +492,18 @@ class UtilTest(unittest.TestCase):
         # Check 1st and last generated configurations completely:
         first_expected_dict = {'float1': -1.0, 'int1': 0}
         last_expected_dict = {'float1': -1.0, 'int1': 1000, 'int2_cond': 100, 'float2_cond': 100.0}
+
         self.assertEqual(generated_grid[0].get_dictionary(), first_expected_dict)
-        self.assertEqual(generated_grid[-1].get_dictionary(), last_expected_dict)
+
+        # This was having slight numerical instability (99.99999999999994 vs 100.0) and so
+        # we manually do a pass over each value
+        last_generated_dict = generated_grid[-1].get_dictionary()
+        for k, expected_value in last_expected_dict.items():
+            generated_value = last_generated_dict[k]
+            if isinstance(generated_value, float):
+                assert generated_value == approx(expected_value)
+            else:
+                assert generated_value == expected_value
         # Here, we test that a few randomly chosen values in the generated grid
         # correspond to the ones I checked.
         self.assertEqual(generated_grid[3].get_dictionary()['int1'], 1000)


### PR DESCRIPTION
Seems there was some issue with `AssertAlmostEqual` will call `round(np.ndarray)`, causing the issue that `Type: np.ndarray has no __round__ method`. Solution was just to unpack the single element arrays

Also fixes an issue where `ConfigSpace.util::generate_grid` was converting log uniforms from float to int with `vec.astype(int)` instead of `np.round(vec)`, which cause occasional failures due to something like `99.9999999` being converted to `99` instead of `100`.