### PR TITLE
Pick the default of categorical hyperparameters based on the weights

### DIFF
--- a/ConfigSpace/hyperparameters/categorical.pyx
+++ b/ConfigSpace/hyperparameters/categorical.pyx
@@ -88,6 +88,8 @@ cdef class CategoricalHyperparameter(Hyperparameter):
         self.choices = tuple(choices)
         if weights is not None:
             self.weights = tuple(weights)
+        else:
+            self.weights = None
         self.probabilities = self._get_probabilities(choices=self.choices, weights=weights)
         self.num_choices = len(choices)
         self.choices_vector = list(range(self.num_choices))
@@ -236,7 +238,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
     def check_default(self, default_value: Union[None, str, float, int]
                       ) -> Union[str, float, int]:
         if default_value is None:
-            return self.choices[np.argmax(self.weights) if hasattr(self, "weights") else 0]
+            return self.choices[np.argmax(self.weights) if self.weights is not None else 0]
         elif self.is_legal(default_value):
             return default_value
         else:

--- a/ConfigSpace/hyperparameters/categorical.pyx
+++ b/ConfigSpace/hyperparameters/categorical.pyx
@@ -236,7 +236,7 @@ cdef class CategoricalHyperparameter(Hyperparameter):
     def check_default(self, default_value: Union[None, str, float, int]
                       ) -> Union[str, float, int]:
         if default_value is None:
-            return self.choices[0]
+            return self.choices[np.argmax(self.weights) if hasattr(self, "weights") else 0]
         elif self.is_legal(default_value):
             return default_value
         else:

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1838,6 +1838,13 @@ class TestHyperparameters(unittest.TestCase):
         ):
             CategoricalHyperparameter('param', ['a', None])
 
+    def test_categorical_default(self):
+        f1 = CategoricalHyperparameter("param", ["a", "b"])
+        f2 = CategoricalHyperparameter("param", ["a", "b"], weights=[0.3, 0.6])
+        f3 = CategoricalHyperparameter("param", ["a", "b"], weights=[0.6, 0.3])
+        self.assertNotEqual(f1.default_value, f2.default_value)
+        self.assertEqual(f1.default_value, f3.default_value)
+
     def test_sample_UniformFloatHyperparameter(self):
         # This can sample four distributions
         def sample(hp):

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1839,6 +1839,7 @@ class TestHyperparameters(unittest.TestCase):
             CategoricalHyperparameter('param', ['a', None])
 
     def test_categorical_default(self):
+        # Test that the default value is the most probable choice when weights are given
         f1 = CategoricalHyperparameter("param", ["a", "b"])
         f2 = CategoricalHyperparameter("param", ["a", "b"], weights=[0.3, 0.6])
         f3 = CategoricalHyperparameter("param", ["a", "b"], weights=[0.6, 0.3])


### PR DESCRIPTION
This PR fixes #258 

Set the default value of categorical hyperparameters to the most frequent category if weights are given; otherwise, pick the first category as before. 