### PR TITLE
Sampling of neighbors in NormalIntegerHyperparameter

### DIFF
--- a/ConfigSpace/hyperparameters/normal_integer.pyx
+++ b/ConfigSpace/hyperparameters/normal_integer.pyx
@@ -252,7 +252,7 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
         neighbors: set[int] = set()
         center = self._transform(value)
 
-        if bounded:
+        if not bounded:
             float_indices = norm.rvs(
                 loc=mu,
                 scale=sigma,
@@ -260,11 +260,14 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
                 random_state=rs,
             )
         else:
-            float_indices = truncnorm(
+            dist = truncnorm(
                 a = (self.lower - mu) / sigma,
                 b = (self.upper - mu) / sigma,
                 loc=center,
                 scale=sigma,
+            )
+
+            float_indices = dist.rvs(
                 size=number,
                 random_state=rs,
             )
@@ -298,10 +301,10 @@ cdef class NormalIntegerHyperparameter(IntegerHyperparameter):
             # We now have a valid sample, add it to the list of neighbors
             neighbors.add(possible_neighbor)
 
-            if transform:
-                return [self._transform(neighbor) for neighbor in neighbors]
-            else:
-                return list(neighbors)
+        if transform:
+            return [self._transform(neighbor) for neighbor in neighbors]
+        else:
+            return list(neighbors)
 
     def _compute_normalization(self):
         if self.lower is None:

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1259,6 +1259,16 @@ class TestHyperparameters(unittest.TestCase):
         for int_hp in (f1, f2, f3, f4, f5):
             self.assertTrue(np.isinf(int_hp.get_size()))
 
+        # Unbounded case
+        f1 = NormalIntegerHyperparameter("param", 0, 10, q=1)
+        self.assertEqual(f1.get_neighbors(2, np.random.RandomState(9001), number=1), [1])
+        self.assertEqual(f1.get_neighbors(2, np.random.RandomState(9001), number=5), [0, 1, 9, 16, -1])
+
+        # Bounded case
+        f1 = NormalIntegerHyperparameter("param", 0, 10, q=1, lower=-100, upper=100)
+        self.assertEqual(f1.get_neighbors(2, np.random.RandomState(9001), number=1), [-11])
+        self.assertEqual(f1.get_neighbors(2, np.random.RandomState(9001), number=5), [4, 11, 12, 15, -11])
+
     def test_normalint_legal_float_values(self):
         n_iter = NormalIntegerHyperparameter("n_iter", 0, 1., default_value=2.0)
         self.assertIsInstance(n_iter.default_value, int)


### PR DESCRIPTION
This PR resolves #298 
* fix: Fix crash while sampling neighbors in the unbounded case
* fix: Make sampling neighbors in the bounded case respect the bounds
* fix: Make sampling of neighbors respect the `number` parameter
* test: Add tests for the bug
