### PR TITLE
Fixes a bug where get_neighbors of uniform int does not behave correctly

### DIFF
--- a/ConfigSpace/hyperparameters/uniform_integer.pyx
+++ b/ConfigSpace/hyperparameters/uniform_integer.pyx
@@ -242,7 +242,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
             for v in range(lower, center):
                 neighbors.append(v)
 
-            for v in range(center + 1, upper):
+            for v in range(center + 1, upper + 1):
                 neighbors.append(v)
 
             if transform:

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1188,6 +1188,15 @@ class TestHyperparameters(unittest.TestCase):
         self.assertAlmostEqual(c2.get_max_density(), 0.0001)
         self.assertAlmostEqual(c3.get_max_density(), 0.07142857142857142)
 
+    def test_uniformint_get_neighbors(self):
+        rs = np.random.RandomState(seed=1)
+        for i_upper in range(1, 10):
+            c1 = UniformIntegerHyperparameter('param', lower=0, upper=i_upper)
+            for i_value in range(0, i_upper+1):
+                float_value = c1._inverse_transform(np.array([i_value]))[0]
+                neighbors = c1.get_neighbors(float_value, rs, number=i_upper, transform=True)
+                assert set(neighbors) == set(range(i_upper+1))-{i_value}
+
     def test_normalint(self):
         # TODO test for unequal!
         f1 = NormalIntegerHyperparameter("param", 0.5, 5.5)


### PR DESCRIPTION
I was getting an access violation (Python exit code -1073741819 (0xC0000005)) when using `utils.get_random_neighbor` to automatically correct a Configuration with a violated forbidden clause. Digging a bit deeper, it turns out that this problem comes from `get_neighbor` of an integer parameter returning an empty list where 1 value was expected [here](https://github.com/automl/ConfigSpace/blob/main/ConfigSpace/util.pyx#L308).

You can reproduce this behavior (v0.6.1):
```python
import numpy as np
from ConfigSpace import UniformIntegerHyperparameter

int_hp = UniformIntegerHyperparameter('a', lower=0, upper=1)
assert int_hp.is_legal(0)
assert int_hp.is_legal(1)
assert int_hp.get_num_neighbors() == 1

# Try getting neighbors for values: 0 <--> 1
rs = np.random.RandomState()
assert int_hp.get_neighbors(0, rs, transform=True) == [1]  # Assertion fails! An empty list is returned
assert int_hp.get_neighbors(1, rs, transform=True) == [0]

# Check the behavior for bounds (0, 2)
int_hp_2 = UniformIntegerHyperparameter('a', lower=0, upper=2)
assert int_hp_2.get_num_neighbors() == 2
assert int_hp_2.get_neighbors( 0, rs, transform=True) == [1, 2]  # Assertion fails! List only contains [1]
assert int_hp_2.get_neighbors(.5, rs, transform=True) == [0, 2]  # Assertion fails! List only contains [0]
assert int_hp_2.get_neighbors( 1, rs, transform=True) == [0, 1]

# If less neighbors are requested than available, the function works fine
assert int_hp_2.get_neighbors( 0, rs, number=1, transform=True)[0] in [1, 2]
assert int_hp_2.get_neighbors(.5, rs, number=1, transform=True)[0] in [0, 2]
assert int_hp_2.get_neighbors( 1, rs, number=1, transform=True)[0] in [0, 1]
```

As can be seen, this behavior only happens when the nr of requested points is equal or larger than the nr of available neighbors. This commit fixes the bug at [line 245 in uniform_integer.pyx](https://github.com/automl/ConfigSpace/blob/main/ConfigSpace/hyperparameters/uniform_integer.pyx#L245) and adds a test to confirm the behavior:
```python
for v in range(center + 1, upper + 1):
```