### PR TITLE
Fixes grid generation with forbidden clauses #312

### DIFF
--- a/ConfigSpace/util.pyx
+++ b/ConfigSpace/util.pyx
@@ -642,6 +642,12 @@ def generate_grid(configuration_space: ConfigurationSpace,
         try:
             grid_point = Configuration(configuration_space, unchecked_grid_pts[0])
             checked_grid_pts.append(grid_point)
+
+        # When creating a configuration that violates a forbidden clause, simply skip it
+        except ForbiddenValueError:
+            unchecked_grid_pts.popleft()
+            continue
+
         except ValueError as e:
             assert (str(e)[:23] == "Active hyperparameter '" and
                     str(e)[-16:] == "' not specified!"), \

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -547,5 +547,5 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(len(generated_grid), 8)
         self.assertEqual(generated_grid[0].get_dictionary(), {'cat1': 'F', 'ord1': '1'})
         self.assertEqual(generated_grid[1].get_dictionary(), {'cat1': 'F', 'ord1': '2'})
-        self.assertEqual(generated_grid[2].get_dictionary(), {'cat1': 'T', 'ord1': '1', 'int1': 10})
-        self.assertEqual(generated_grid[-1].get_dictionary(), {'cat1': 'T', 'ord1': '3', 'int1': 100})
+        self.assertEqual(generated_grid[2].get_dictionary(), {'cat1': 'T', 'ord1': '1', 'int1': 0})
+        self.assertEqual(generated_grid[-1].get_dictionary(), {'cat1': 'T', 'ord1': '3', 'int1': 1000})


### PR DESCRIPTION
This pull request should fix #312 by simply rejecting generated Configurations that violate any forbidden clause