### PR TITLE
Correct reference to hyperparameter for InactiveHyperparameterSetError

### DIFF
--- a/ConfigSpace/c_util.pyx
+++ b/ConfigSpace/c_util.pyx
@@ -104,6 +104,7 @@ cpdef int check_configuration(
         if not allow_inactive_with_values and not active[hp_idx] and not np.isnan(vector[hp_idx]):
             # Only look up the value (in the line above) if the hyperparameter is inactive!
             hp_name = self._idx_to_hyperparameter[hp_idx]
+            hyperparameter = self._hyperparameters[hp_name]
             hp_value = vector[hp_idx]
             free(active)
             raise InactiveHyperparameterSetError(hyperparameter, hp_value)


### PR DESCRIPTION
Found a bug where `InactiveHyperparameterSetError` refers to the wrong hyperparameter when using `config.is_valid_configuration()`.

Reproduce (ConfigSpace 0.7.1):
```python
from math import nan
from ConfigSpace import ConfigurationSpace, CategoricalHyperparameter, UniformFloatHyperparameter, \
    EqualsCondition, Configuration, InactiveHyperparameterSetError

cs = ConfigurationSpace(space={
    'x0': CategoricalHyperparameter('x0', choices=['A', 'B', 'C']),
    'x1': CategoricalHyperparameter('x1', choices=['D', 'E']),
    'x2': UniformFloatHyperparameter('x2', lower=0, upper=1),
})
cs.add_condition(EqualsCondition(cs['x2'], cs['x0'], 'A'))

# x2 is active: config is valid
config = Configuration(cs, vector=[0, 0, .5])
config.is_valid_configuration()

# x2 is inactive and is NaN: config is valid
config_x2_inactive = Configuration(cs, vector=[1, 0, nan])
config_x2_inactive.is_valid_configuration()

# x2 is inactive and has value: config is invalid and raised exception should refer to x2
config_x2_inactive = Configuration(cs, vector=[1, 0, .5])
try:
    config_x2_inactive.is_valid_configuration()
    raise RuntimeError('Should not be here')

except InactiveHyperparameterSetError as e:
    # Inactive hyperparameter should be x2
    # Not true in ConfigSpace 0.7.1!
    assert e.hyperparameter is cs['x2']
```

This pull request should fix this bug.