### PR TITLE
feat(Hyperparameter): Allow `None` in `Categorical` and `Ordinal`

### DIFF
--- a/src/ConfigSpace/conditions.py
+++ b/src/ConfigSpace/conditions.py
@@ -37,19 +37,11 @@ from typing_extensions import Self, override
 
 import numpy as np
 
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
     from ConfigSpace.types import Array, Mask
-
-
-class _NotSet:
-    def __repr__(self):
-        return "ValueNotSetObject"
-
-
-NotSet = _NotSet()  # Sentinal value for unset values
 
 
 class Condition(ABC):

--- a/src/ConfigSpace/configuration.py
+++ b/src/ConfigSpace/configuration.py
@@ -6,10 +6,9 @@ from typing_extensions import deprecated
 
 import numpy as np
 
-from ConfigSpace.conditions import NotSet
 from ConfigSpace.exceptions import IllegalValueError
 from ConfigSpace.hyperparameters import FloatHyperparameter
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace

--- a/src/ConfigSpace/hyperparameters/categorical.py
+++ b/src/ConfigSpace/hyperparameters/categorical.py
@@ -14,7 +14,7 @@ from ConfigSpace.hyperparameters._distributions import (
 )
 from ConfigSpace.hyperparameters._hp_components import TransformerSeq, _Neighborhood
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, f64
+from ConfigSpace.types import Array, NotSet, _NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.types import Array
@@ -89,15 +89,10 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
         self,
         name: str,
         choices: Sequence[Any],
-        default_value: Any | None = None,
+        default_value: Any | _NotSet = NotSet,
         meta: Mapping[Hashable, Any] | None = None,
         weights: Sequence[float] | Array[np.number] | None = None,
     ) -> None:
-        # TODO: We can allow for None but we need to be sure it doesn't break
-        # anything elsewhere.
-        if any(choice is None for choice in choices):
-            raise TypeError("Choice 'None' is not supported")
-
         if isinstance(choices, Set):
             raise TypeError(
                 "Using a set of choices is prohibited as it can result in "
@@ -146,7 +141,7 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
         else:
             tupled_weights = None
 
-        if default_value is not None and default_value not in choices:
+        if default_value is not NotSet and default_value not in choices:
             raise ValueError(
                 "The default value has to be one of the choices. "
                 f"Got {default_value!r} which is not in {choices}.",
@@ -159,9 +154,9 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
             _weights = np.asarray(weights, dtype=np.float64)
             probabilities = _weights / np.sum(_weights)
 
-        if default_value is None and weights is None:
+        if default_value is NotSet and weights is None:
             default_value = choices[0]
-        elif default_value is None:
+        elif default_value is NotSet:
             highest_prob_index = np.argmax(probabilities)
             default_value = choices[highest_prob_index]
         elif default_value in choices:
@@ -236,8 +231,8 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
 
         return True
 
-    def _neighborhood_size(self, value: Any | None) -> int:
-        if value is None or value not in self.choices:
+    def _neighborhood_size(self, value: Any | _NotSet) -> int:
+        if value is NotSet or value not in self.choices:
             return self.size
         return self.size - 1
 

--- a/src/ConfigSpace/hyperparameters/ordinal.py
+++ b/src/ConfigSpace/hyperparameters/ordinal.py
@@ -32,7 +32,7 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
         self,
         name: str,
         sequence: Sequence[Any],
-        default_value: Any | None = None,
+        default_value: Any | _NotSet = NotSet,
         meta: Mapping[Hashable, Any] | None = None,
     ) -> None:
         # TODO: Maybe give some way to not check this, i.e. for large sequences
@@ -45,7 +45,7 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
             )
 
         size = len(sequence)
-        if default_value is None:
+        if default_value is NotSet:
             default_value = sequence[0]
         elif default_value not in sequence:
             raise ValueError(

--- a/src/ConfigSpace/util.py
+++ b/src/ConfigSpace/util.py
@@ -50,6 +50,7 @@ from ConfigSpace.hyperparameters import (
     UniformFloatHyperparameter,
     UniformIntegerHyperparameter,
 )
+from ConfigSpace.types import NotSet
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace
@@ -86,8 +87,8 @@ def impute_inactive_values(
     """
     values = {}
     for hp in configuration.config_space.values():
-        value = configuration.get(hp.name)
-        if value is None:
+        value = configuration.get(hp.name, NotSet)
+        if value is NotSet:
             if strategy == "default":
                 new_value = hp.default_value
 


### PR DESCRIPTION
* **Based on branch `typing-cython-3`, should be retargeted to `main` once rebased onto `typing-cython-3`**

This PR allows `Choice` and `Ordinal` to handle `None` values.