### PR TITLE
feat(Hyperparameters): Allow arbitrary objects in category ordinal

### DIFF
--- a/src/ConfigSpace/api/types/categorical.py
+++ b/src/ConfigSpace/api/types/categorical.py
@@ -5,6 +5,7 @@ from typing import Literal, Union, overload
 from typing_extensions import TypeAlias
 
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, OrdinalHyperparameter
+from ConfigSpace.types import NotSet, _NotSet
 
 # We only accept these types in `items`
 T: TypeAlias = Union[str, int, float]
@@ -16,7 +17,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: Literal[False],
     meta: dict | None = None,
@@ -29,7 +30,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: Literal[True],
     meta: dict | None = None,
@@ -42,7 +43,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: bool = ...,
     meta: dict | None = None,
@@ -53,7 +54,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: bool = False,
     meta: dict | None = None,

--- a/src/ConfigSpace/conditions.py
+++ b/src/ConfigSpace/conditions.py
@@ -37,19 +37,11 @@ from typing_extensions import Self, override
 
 import numpy as np
 
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
     from ConfigSpace.types import Array, Mask
-
-
-class _NotSet:
-    def __repr__(self):
-        return "ValueNotSetObject"
-
-
-NotSet = _NotSet()  # Sentinal value for unset values
 
 
 class Condition(ABC):

--- a/src/ConfigSpace/configuration.py
+++ b/src/ConfigSpace/configuration.py
@@ -6,10 +6,9 @@ from typing_extensions import deprecated
 
 import numpy as np
 
-from ConfigSpace.conditions import NotSet
 from ConfigSpace.exceptions import IllegalValueError
 from ConfigSpace.hyperparameters import FloatHyperparameter
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace

--- a/src/ConfigSpace/hyperparameters/categorical.py
+++ b/src/ConfigSpace/hyperparameters/categorical.py
@@ -14,7 +14,7 @@ from ConfigSpace.hyperparameters._distributions import (
 )
 from ConfigSpace.hyperparameters._hp_components import TransformerSeq, _Neighborhood
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, f64
+from ConfigSpace.types import Array, NotSet, _NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.types import Array
@@ -89,15 +89,10 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
         self,
         name: str,
         choices: Sequence[Any],
-        default_value: Any | None = None,
+        default_value: Any | _NotSet = NotSet,
         meta: Mapping[Hashable, Any] | None = None,
         weights: Sequence[float] | Array[np.number] | None = None,
     ) -> None:
-        # TODO: We can allow for None but we need to be sure it doesn't break
-        # anything elsewhere.
-        if any(choice is None for choice in choices):
-            raise TypeError("Choice 'None' is not supported")
-
         if isinstance(choices, Set):
             raise TypeError(
                 "Using a set of choices is prohibited as it can result in "
@@ -146,7 +141,7 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
         else:
             tupled_weights = None
 
-        if default_value is not None and default_value not in choices:
+        if default_value is not NotSet and default_value not in choices:
             raise ValueError(
                 "The default value has to be one of the choices. "
                 f"Got {default_value!r} which is not in {choices}.",
@@ -159,9 +154,9 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
             _weights = np.asarray(weights, dtype=np.float64)
             probabilities = _weights / np.sum(_weights)
 
-        if default_value is None and weights is None:
+        if default_value is NotSet and weights is None:
             default_value = choices[0]
-        elif default_value is None:
+        elif default_value is NotSet:
             highest_prob_index = np.argmax(probabilities)
             default_value = choices[highest_prob_index]
         elif default_value in choices:
@@ -236,8 +231,8 @@ class CategoricalHyperparameter(Hyperparameter[Any, Any]):
 
         return True
 
-    def _neighborhood_size(self, value: Any | None) -> int:
-        if value is None or value not in self.choices:
+    def _neighborhood_size(self, value: Any | _NotSet) -> int:
+        if value is NotSet or value not in self.choices:
             return self.size
         return self.size - 1
 

--- a/src/ConfigSpace/hyperparameters/hyperparameter.py
+++ b/src/ConfigSpace/hyperparameters/hyperparameter.py
@@ -241,13 +241,10 @@ class Hyperparameter(ABC, Generic[ValueT, DType]):
         return value
 
     @overload
-    def to_vector(self, value: ValueT | DType) -> f64: ...
+    def to_vector(self, value: ValueT | DType | Sequence[ValueT | DType]) -> f64: ...
 
     @overload
-    def to_vector(
-        self,
-        value: Sequence[ValueT | DType] | Array[Any],
-    ) -> Array[f64]: ...
+    def to_vector(self, value: Sequence[ValueT | DType] | Array[Any]) -> Array[f64]: ...
 
     def to_vector(
         self,
@@ -300,19 +297,11 @@ class Hyperparameter(ABC, Generic[ValueT, DType]):
         legal_mask = self.legal_vector(vector).astype(f64)
         return self._vector_dist.pdf_vector(vector) * legal_mask
 
-    def pdf_values(
-        self,
-        values: Sequence[DType] | Array[DType],
-    ) -> Array[f64]:
-        # TODO: why this restriction?
-        _values = np.asarray(values)
-        if _values.ndim != 1:
-            raise ValueError(
-                "Method pdf expects a one-dimensional numpy array but got"
-                f" {_values.ndim} dimensions."
-                f"\n{_values}",
-            )
-        vector = self.to_vector(_values)
+    def pdf_values(self, values: Sequence[DType] | Array[DType]) -> Array[f64]:
+        if isinstance(values, np.ndarray) and values.ndim != 1:
+            raise ValueError("Method pdf expects a one-dimensional numpy array")
+
+        vector = self.to_vector(values)
         return self.pdf_vector(vector)
 
     def copy(self, **kwargs: Any) -> Self:

--- a/src/ConfigSpace/hyperparameters/ordinal.py
+++ b/src/ConfigSpace/hyperparameters/ordinal.py
@@ -32,7 +32,7 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
         self,
         name: str,
         sequence: Sequence[Any],
-        default_value: Any | None = None,
+        default_value: Any | _NotSet = NotSet,
         meta: Mapping[Hashable, Any] | None = None,
     ) -> None:
         # TODO: Maybe give some way to not check this, i.e. for large sequences
@@ -45,7 +45,7 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
             )
 
         size = len(sequence)
-        if default_value is None:
+        if default_value is NotSet:
             default_value = sequence[0]
         elif default_value not in sequence:
             raise ValueError(

--- a/src/ConfigSpace/hyperparameters/ordinal.py
+++ b/src/ConfigSpace/hyperparameters/ordinal.py
@@ -4,7 +4,7 @@ from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, ClassVar
-from typing_extensions import deprecated
+from typing_extensions import deprecated, override
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from ConfigSpace.hyperparameters._hp_components import (
     ordinal_neighborhood,
 )
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, NotSet, _NotSet, i64
+from ConfigSpace.types import Array, Mask, NotSet, _NotSet, f64, i64
 
 
 @dataclass(init=False)
@@ -27,6 +27,8 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
     default_value: Any
     meta: Mapping[Hashable, Any] | None
     size: int
+
+    _contains_sequence_as_value: bool
 
     def __init__(
         self,
@@ -53,16 +55,31 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
                 f"Got {default_value!r} which is not in {sequence}.",
             )
 
-        seq_choices = np.asarray(sequence)
-        # NOTE: Unfortunatly, numpy will promote number types to str
-        # if there are string types in the array, where we'd rather
-        # stick to object type in that case. Hence the manual...
-        if seq_choices.dtype.kind in {"U", "S"} and not all(
-            isinstance(item, str) for item in sequence
-        ):
-            seq_choices = np.asarray(sequence, dtype=object)
+        try:
+            # This can fail with a ValueError if the choices contain arbitrary objects
+            # that are list like.
+            seq_choices = np.asarray(sequence)
+
+            # NOTE: Unfortunatly, numpy will promote number types to str
+            # if there are string types in the array, where we'd rather
+            # stick to object type in that case. Hence the manual...
+            if seq_choices.dtype.kind in {"U", "S"} and not all(
+                isinstance(item, str) for item in sequence
+            ):
+                seq_choices = np.array(sequence, dtype=object)
+
+        except ValueError:
+            seq_choices = list(sequence)
 
         self.sequence = tuple(sequence)
+
+        # If the Hyperparameter recieves as a Sequence during legality checks or
+        # conversions, we need to inform it that one of the values is a Sequence itself,
+        # i.e. we should treat it as a single value and not a list of multiple values
+        self._contains_sequence_as_value = any(
+            isinstance(item, Sequence) and not isinstance(item, str)
+            for item in self.sequence
+        )
 
         super().__init__(
             name=name,
@@ -120,3 +137,73 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
     @deprecated("Please use 'len(hp.sequence)' or `hp.size` instead.")
     def num_elements(self) -> int:
         return self.size
+
+    @override
+    def to_vector(self, value: Any | Sequence[Any] | Array[Any]) -> f64 | Array[f64]:
+        if isinstance(value, np.ndarray):
+            return self._transformer.to_vector(value)
+
+        if isinstance(value, str):
+            return self._transformer.to_vector(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.to_vector(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.to_vector(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.to_vector(np.array([value]))[0]
+
+    @override
+    def legal_value(self, value: Any | Sequence[Any] | Array[Any]) -> bool | Mask:
+        if isinstance(value, np.ndarray):
+            return self._transformer.legal_value(value)
+
+        if isinstance(value, str):
+            return self._transformer.legal_value(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.legal_value(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.legal_value(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.legal_value(np.array([value]))[0]
+
+    @override
+    def pdf_values(self, values: Sequence[Any] | Array[Any]) -> Array[f64]:
+        if isinstance(values, np.ndarray):
+            if values.ndim != 1:
+                raise ValueError("Method pdf expects a one-dimensional numpy array")
+
+            vector = self.to_vector(values)
+            return self.pdf_vector(vector)
+
+        if self._contains_sequence_as_value:
+            # We have to convert it into a numpy array of objects carefully
+            # https://stackoverflow.com/a/47389566/5332072
+            _v = np.empty(len(values), dtype=object)
+            _v[:] = values
+            _vector: Array[f64] = self.to_vector(_v)  # type: ignore
+            return self.pdf_vector(_vector)
+
+        vector: Array[f64] = self.to_vector(values)  # type: ignore
+        return self.pdf_vector(vector)

--- a/src/ConfigSpace/util.py
+++ b/src/ConfigSpace/util.py
@@ -50,6 +50,7 @@ from ConfigSpace.hyperparameters import (
     UniformFloatHyperparameter,
     UniformIntegerHyperparameter,
 )
+from ConfigSpace.types import NotSet
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace
@@ -86,8 +87,8 @@ def impute_inactive_values(
     """
     values = {}
     for hp in configuration.config_space.values():
-        value = configuration.get(hp.name)
-        if value is None:
+        value = configuration.get(hp.name, NotSet)
+        if value is NotSet:
             if strategy == "default":
                 new_value = hp.default_value
 


### PR DESCRIPTION
* * **Based on branch `typing-cython-3`, should be retargeted to `main` once rebased onto `typing-cython-3`**


Allows arbitrary objects to be handled in categoricals and ordinals