### PR TITLE
Bugfix for problematic typecheck when creating Integer

### DIFF
--- a/ConfigSpace/hyperparameters/uniform_integer.pyx
+++ b/ConfigSpace/hyperparameters/uniform_integer.pyx
@@ -83,7 +83,7 @@ cdef class UniformIntegerHyperparameter(IntegerHyperparameter):
                                                self.lower - 0.49999,
                                                self.upper + 0.49999,
                                                log=self.log,
-                                               default_value=self.default_value)
+                                               default_value=float(self.default_value))
 
         self.normalized_default_value = self._inverse_transform(self.default_value)
 


### PR DESCRIPTION
When creating a UniformIntHyperparameter, the default_value is parsed as an int to the uniformFloatHyperparameter, which causes the type_check in line 62 to fail.

This is obviously a bug. This type conversion should fix the bug.