### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/ConfigSpace/nx/algorithms/dag.py
+++ b/ConfigSpace/nx/algorithms/dag.py
@@ -289,5 +289,4 @@ def is_aperiodic(G):
         level += 1
     if len(levels) == len(G):  # All nodes in tree
         return g == 1
-    else:
-        return g == 1 and ConfigSpace.nx.is_aperiodic(G.subgraph(set(G) - set(levels)))
+    return g == 1 and ConfigSpace.nx.is_aperiodic(G.subgraph(set(G) - set(levels)))

--- a/ConfigSpace/nx/classes/digraph.py
+++ b/ConfigSpace/nx/classes/digraph.py
@@ -899,10 +899,9 @@ class DiGraph(Graph):
         >>> list(G.in_degree([0,1]).values())
         [0, 1]
         """
-        if nbunch in self:  # return a single node
+        if nbunch in self:
             return next(self.in_degree_iter(nbunch, weight))[1]
-        else:  # return a dict
-            return dict(self.in_degree_iter(nbunch, weight))
+        return dict(self.in_degree_iter(nbunch, weight))
 
     def out_degree(self, nbunch=None, weight=None):
         """Return the out-degree of a node or nodes.
@@ -939,10 +938,9 @@ class DiGraph(Graph):
 
 
         """
-        if nbunch in self:  # return a single node
+        if nbunch in self:
             return next(self.out_degree_iter(nbunch, weight))[1]
-        else:  # return a dict
-            return dict(self.out_degree_iter(nbunch, weight))
+        return dict(self.out_degree_iter(nbunch, weight))
 
     def clear(self):
         """Remove all nodes and edges from the graph.

--- a/ConfigSpace/nx/classes/graph.py
+++ b/ConfigSpace/nx/classes/graph.py
@@ -1235,10 +1235,9 @@ class Graph:
         [1, 2]
 
         """
-        if nbunch in self:  # return a single node
+        if nbunch in self:
             return next(self.degree_iter(nbunch, weight))[1]
-        else:  # return a dict
-            return dict(self.degree_iter(nbunch, weight))
+        return dict(self.degree_iter(nbunch, weight))
 
     def degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, degree).
@@ -1555,8 +1554,7 @@ class Graph:
         """
         if data:
             return [(n, n, nbrs[n]) for n, nbrs in self.adj.items() if n in nbrs]
-        else:
-            return [(n, n) for n, nbrs in self.adj.items() if n in nbrs]
+        return [(n, n) for n, nbrs in self.adj.items() if n in nbrs]
 
     def number_of_selfloops(self):
         """Return the number of selfloop edges.
@@ -1616,10 +1614,7 @@ class Graph:
         6.0
         """
         s = sum(self.degree(weight=weight).values()) / 2
-        if weight is None:
-            return int(s)
-        else:
-            return float(s)
+        return int(s) if weight is None else float(s)
 
     def number_of_edges(self, u=None, v=None):
         """Return the number of edges between two nodes.
@@ -1656,8 +1651,7 @@ class Graph:
             return int(self.size())
         if v in self.adj[u]:
             return 1
-        else:
-            return 0
+        return 0
 
     def add_star(self, nodes, **attr):
         """Add a star.


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.