### PR TITLE
fix(Constant): Use `object` dtype with array creation

### DIFF
--- a/src/ConfigSpace/types.py
+++ b/src/ConfigSpace/types.py
@@ -27,6 +27,9 @@ for example a `np.int64`.
 Array: TypeAlias = npt.NDArray[DType]
 """Array, a numpy array of a specific dtype."""
 
+ObjectArray: TypeAlias = npt.NDArray[np.object_]
+"""Object array, a numpy array of objects."""
+
 f64: TypeAlias = np.float64
 """64-bit floating point number."""
 


### PR DESCRIPTION
* Closes #374 

Issue is described there, the fix was to just use an `object` as the dtype for the numpy array.