### PR TITLE
feat: Allow arbitrary values as categoricals/constants/ordinals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Version 1.1.0
+
+* FEAT #376: Allow arbitrary values for `Categorical`, `Ordinal`, and `Constant` hyperparameters.
+* FIX #375: Use `object` dtype for `Constant` np.array of values to prevent numpy type conversions of values.
+
+
 # Version 1.0.1
 
 * FIX #373: Fix `ForbiddenEqualsRelation` when evaluating on vectors of values.
@@ -92,7 +98,7 @@
 
 # Version 0.4.15
 
-* Add `pyproject.toml` to support wheel installation as required in 
+* Add `pyproject.toml` to support wheel installation as required in
   [PEP518](https://medium.com/@grassfedcode/pep-517-and-518-in-plain-english-47208ca8b7a6)
 
 # Version 0.4.14
@@ -120,7 +126,7 @@
 * ADD #135: Add weights to the sampling of categorical hyperparameters.
 * MAINT #129: Performance improvements for the generation of neighbor configurations.
 * MAINT #130: Test the installability of a distribution on travis-ci.
-* FIX #140: Fixes a bug which led to samples lower than the lower bound of 
+* FIX #140: Fixes a bug which led to samples lower than the lower bound of
   `UniformFloatHyperparemeter` if the lower bound was larger than zero and quantization was used.
 * FIX # 138: Fixes a bug in which the readme wasn't read correctly on systems not using UTF8 as
   their default encoding.
@@ -145,7 +151,7 @@
 
 # Version 0.4.9
 
-* Fixes an issue where adding a new forbidden for an unknown hyperparameter 
+* Fixes an issue where adding a new forbidden for an unknown hyperparameter
   did not result in an immediate exception.
 * Add a new argument `vector` to `util.deactivate_inactive_hyperparameters`
 * Make the number of categories a public variable for categorical and
@@ -153,21 +159,21 @@
 
 # Version 0.4.8
 
-* Fixes an issue which made serialization of `ForbiddenInCondition` to json 
+* Fixes an issue which made serialization of `ForbiddenInCondition` to json
   fail.
-* MAINT #101: Improved error message on setting illegal value in a 
+* MAINT #101: Improved error message on setting illegal value in a
   configuration.
 * DOC #91: Added a documentation to automl.github.io/ConfigSpace
 
 # Version 0.4.7
 
 * Tests Python3.7.
-* Fixes #87: better handling of Conjunctions when adding them to the 
+* Fixes #87: better handling of Conjunctions when adding them to the
   configuration space.
 * MAINT: Improved type annotation in `util.py` which results in improved
   performance (due to better Cython optimization).
-* MAINT: `util.get_one_exchange_neighborhood` now accepts two arguments 
-  `num_neighbors` and `stdev` which govern the neighborhood creation behaviour 
+* MAINT: `util.get_one_exchange_neighborhood` now accepts two arguments
+  `num_neighbors` and `stdev` which govern the neighborhood creation behaviour
   of several continuous hyperparameters.
 * NEW #85: Add function to obtain active hyperparameters
 * NEW #84: Add field for meta-data to the configuration space object.
@@ -291,21 +297,21 @@
 
 # Version 0.2.1
 
-* FIX: bug which changed order of hyperparameters when adding new 
-  hyperparameter. This was non-deterministic due to the use of dict instead 
+* FIX: bug which changed order of hyperparameters when adding new
+  hyperparameter. This was non-deterministic due to the use of dict instead
   of OrderedDict.
 * FIX: compare configurations with == instead of numpy.allclose.
 * FIX: issue 2, syntax error no longer present during installation
 * FIX: json serialization of configurations and their hyperparameters can now
-       be deserialized by json and still compare equal 
+       be deserialized by json and still compare equal
 
 # Version 0.2
 
-* FIX: bug which made integer values have different float values in the 
+* FIX: bug which made integer values have different float values in the
   underlying vector representation.
-* FIX: bug which could make two configuration spaces compare unequal due to 
+* FIX: bug which could make two configuration spaces compare unequal due to
   the use of defaultdict
-* FEATURE: new feature add_configuration_space, which allows to add a whole 
+* FEATURE: new feature add_configuration_space, which allows to add a whole
   configuration space into an existing configuration space
 * FEATURE: python3.5 support
 * FIX: add function get_parent() to Conjunctions (issue #1)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,28 @@ Those are introduced in the [user guide](./guide.md)
     * You can now use your editor to jump to definition and see the source code.
     * Contribute more easily!
 
+    There is no also better support in Categorical, Ordinal and Constant hyperparameters,
+    for arbitrary values, for example:
+
+    ```python
+    from dataclasses import dataclass
+    from ConfigSpace import ConfigurationSpace, Constant
+
+    @dataclass
+    class A:
+        a: int
+
+    def f() -> None:
+        return None
+
+    cs = ConfigurationSpace({
+        "cat": [True, False, None],
+        "othercat": [A(1), f],
+        "constant": Constant("constant": (24, 25)),
+    })
+    ```
+
+
     With this, we have also deprecated many of the previous functions, simplifying the API
     where possible or improving it's clarity. We have tried hard to keep everything backwards
     compatible, and also recommend the new functionality to use!

--- a/src/ConfigSpace/api/types/categorical.py
+++ b/src/ConfigSpace/api/types/categorical.py
@@ -5,6 +5,7 @@ from typing import Literal, Union, overload
 from typing_extensions import TypeAlias
 
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, OrdinalHyperparameter
+from ConfigSpace.types import NotSet, _NotSet
 
 # We only accept these types in `items`
 T: TypeAlias = Union[str, int, float]
@@ -16,7 +17,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: Literal[False],
     meta: dict | None = None,
@@ -29,7 +30,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: Literal[True],
     meta: dict | None = None,
@@ -42,7 +43,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: bool = ...,
     meta: dict | None = None,
@@ -53,7 +54,7 @@ def Categorical(
     name: str,
     items: Sequence[T],
     *,
-    default: T | None = None,
+    default: T | _NotSet = NotSet,
     weights: Sequence[float] | None = None,
     ordered: bool = False,
     meta: dict | None = None,

--- a/src/ConfigSpace/conditions.py
+++ b/src/ConfigSpace/conditions.py
@@ -37,19 +37,11 @@ from typing_extensions import Self, deprecated, override
 import numpy as np
 from more_itertools import all_equal, unique_everseen
 
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
     from ConfigSpace.types import Array, Mask
-
-
-class _NotSet:
-    def __repr__(self) -> str:
-        return "ValueNotSetObject"
-
-
-NotSet = _NotSet()  # Sentinal value for unset values
 
 
 class Condition(ABC):

--- a/src/ConfigSpace/configuration.py
+++ b/src/ConfigSpace/configuration.py
@@ -6,10 +6,9 @@ from typing_extensions import deprecated
 
 import numpy as np
 
-from ConfigSpace.conditions import NotSet
 from ConfigSpace.exceptions import IllegalValueError
 from ConfigSpace.hyperparameters import FloatHyperparameter
-from ConfigSpace.types import f64
+from ConfigSpace.types import NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace

--- a/src/ConfigSpace/configuration_space.py
+++ b/src/ConfigSpace/configuration_space.py
@@ -110,9 +110,9 @@ def _parse_hyperparameters_from_dict(
                 raise ValueError(f"Can't have empty list for categorical {name}")
 
             yield CategoricalHyperparameter(name, hp)
-
-        # It's a constant
-        yield Constant(name, hp)
+        else:
+            # It's a constant
+            yield Constant(name, hp)
 
 
 class ConfigurationSpace(Mapping[str, Hyperparameter]):

--- a/src/ConfigSpace/configuration_space.py
+++ b/src/ConfigSpace/configuration_space.py
@@ -111,12 +111,8 @@ def _parse_hyperparameters_from_dict(
 
             yield CategoricalHyperparameter(name, hp)
 
-        # If it's an allowed type, it's a constant
-        elif isinstance(hp, (int, str, float)):
-            yield Constant(name, hp)
-
-        else:
-            raise ValueError(f"Unknown value '{hp}' for '{name}'")
+        # It's a constant
+        yield Constant(name, hp)
 
 
 class ConfigurationSpace(Mapping[str, Hyperparameter]):

--- a/src/ConfigSpace/hyperparameters/categorical.py
+++ b/src/ConfigSpace/hyperparameters/categorical.py
@@ -16,7 +16,7 @@ from ConfigSpace.hyperparameters.distributions import (
 )
 from ConfigSpace.hyperparameters.hp_components import Neighborhood, TransformerSeq
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, NotSet, _NotSet, f64
+from ConfigSpace.types import Array, Mask, NotSet, _NotSet, f64
 
 if TYPE_CHECKING:
     from ConfigSpace.types import Array

--- a/src/ConfigSpace/hyperparameters/constant.py
+++ b/src/ConfigSpace/hyperparameters/constant.py
@@ -64,13 +64,6 @@ class Constant(Hyperparameter[Any, Any]):
                 Field for holding meta data provided by the user.
                 Not used by the configuration space.
         """
-        # TODO: This should be changed and allowed...
-        if not isinstance(value, (int, float, str)) or isinstance(value, bool):
-            raise TypeError(
-                f"Constant hyperparameter '{name}' must be of type int, float or str, "
-                f"but got {type(value).__name__}.",
-            )
-
         self.value = value
 
         super().__init__(

--- a/src/ConfigSpace/hyperparameters/constant.py
+++ b/src/ConfigSpace/hyperparameters/constant.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar
+from typing_extensions import override
 
 import numpy as np
 
 from ConfigSpace.hyperparameters.distributions import ConstantVectorDistribution
 from ConfigSpace.hyperparameters.hp_components import TransformerConstant
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, f64
+from ConfigSpace.types import Array, Mask, f64
 
 CONSTANT_VECTOR_VALUE_YES = f64(1)
 """Vectorized value for constant when set."""
@@ -44,6 +45,8 @@ class Constant(Hyperparameter[Any, Any]):
     size: int
     """Size of the hyperparameter, which is always 1 for a constant hyperparameter."""
 
+    _contains_sequence_as_value: bool = False
+
     def __init__(
         self,
         name: str,
@@ -64,7 +67,15 @@ class Constant(Hyperparameter[Any, Any]):
                 Field for holding meta data provided by the user.
                 Not used by the configuration space.
         """
+        if isinstance(value, np.ndarray):
+            raise ValueError(
+                "Constant hyperparameter does not support numpy arrays as values",
+            )
         self.value = value
+        self._contains_sequence_as_value = isinstance(
+            value,
+            Sequence,
+        ) and not isinstance(value, str)
 
         super().__init__(
             name=name,
@@ -92,6 +103,76 @@ class Constant(Hyperparameter[Any, Any]):
         ]
 
         return ", ".join(parts)
+
+    @override
+    def legal_value(self, value: Any | Sequence[Any] | Array[Any]) -> bool | Mask:
+        if isinstance(value, np.ndarray):
+            return self._transformer.legal_value(value)
+
+        if isinstance(value, str):
+            return self._transformer.legal_value(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.legal_value(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.legal_value(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.legal_value(np.array([value]))[0]
+
+    @override
+    def pdf_values(self, values: Sequence[Any] | Array[Any]) -> Array[f64]:
+        if isinstance(values, np.ndarray):
+            if values.ndim != 1:
+                raise ValueError("Method pdf expects a one-dimensional numpy array")
+
+            vector = self.to_vector(values)  # type: ignore
+            return self.pdf_vector(vector)
+
+        if self._contains_sequence_as_value:
+            # We have to convert it into a numpy array of objects carefully
+            # https://stackoverflow.com/a/47389566/5332072
+            _v = np.empty(len(values), dtype=object)
+            _v[:] = values
+            _vector: Array[f64] = self.to_vector(_v)  # type: ignore
+            return self.pdf_vector(_vector)
+
+        vector: Array[f64] = self.to_vector(values)  # type: ignore
+        return self.pdf_vector(vector)
+
+    @override
+    def to_vector(self, value: Any | Sequence[Any] | Array[Any]) -> f64 | Array[f64]:
+        if isinstance(value, np.ndarray):
+            return self._transformer.to_vector(value)
+
+        if isinstance(value, str):
+            return self._transformer.to_vector(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.to_vector(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.to_vector(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.to_vector(np.array([value]))[0]
 
 
 UnParametrizedHyperparameter = Constant  # Legacy

--- a/src/ConfigSpace/hyperparameters/hp_components.py
+++ b/src/ConfigSpace/hyperparameters/hp_components.py
@@ -126,7 +126,7 @@ class TransformerSeq(Transformer[Any]):
         seq: The sequence of values to transform.
     """
 
-    seq: Array[Any]
+    seq: Array[Any] | list[Any]  # If `list`, assumed to contain sequence objects
     """The original sequence of values."""
 
     lower_vectorized: f64 = field(init=False)
@@ -172,20 +172,40 @@ class TransformerSeq(Transformer[Any]):
                 f" representation into a value in {self.seq}."
                 f"Expected integers but got {vector} (dtype: {vector.dtype})",
             )
-        indices: Array[np.intp] = np.rint(vector).astype(np.intp)
-        return self.seq[indices]  # type: ignore
+
+        if isinstance(self.seq, np.ndarray):
+            indices = np.rint(vector).astype(i64)
+            return self.seq[indices]
+
+        items = [self.seq[int(np.rint(i))] for i in vector]
+        if isinstance(self.seq, list):
+            # We have to convert it into a numpy array of objects carefully
+            # https://stackoverflow.com/a/47389566/5332072
+            _v = np.empty(len(items), dtype=object)
+            _v[:] = items
+            return _v
+
+        return np.array(items, dtype=object)
 
     @override
     def to_vector(self, value: Array[Any]) -> Array[f64]:
         if self._lookup is not None:
             return np.array([self._lookup[v] for v in value], dtype=f64)
-        return np.flatnonzero(np.isin(self.seq, value)).astype(f64)
+
+        if isinstance(self.seq, np.ndarray):
+            return np.flatnonzero(np.isin(self.seq, value)).astype(f64)
+
+        return np.array([self.seq.index(v) for v in value], dtype=f64)
 
     @override
     def legal_value(self, value: Array[Any]) -> Mask:
         if self._lookup is not None:
             return np.array([v in self._lookup for v in value], dtype=np.bool_)
-        return np.isin(value, self.seq)
+
+        if isinstance(self.seq, np.ndarray):
+            return np.isin(value, self.seq)
+
+        return np.array([v in self.seq for v in value], dtype=np.bool_)
 
     @override
     def legal_vector(self, vector: Array[f64]) -> Mask:

--- a/src/ConfigSpace/hyperparameters/hp_components.py
+++ b/src/ConfigSpace/hyperparameters/hp_components.py
@@ -503,11 +503,10 @@ class TransformerConstant(Transformer[Any]):
 
     @override
     def to_vector(self, value: ObjectArray) -> Array[f64]:
-        return np.where(
-            value == self.value,
-            self.vector_value_yes,
-            self.vector_value_no,
-        )
+        if isinstance(self.value, np.ndarray):
+            return np.flatnonzero(np.equal(self.value, value)).astype(f64)
+
+        return np.array([v == self.value for v in value], dtype=f64)
 
     @override
     def to_value(self, vector: Array[f64]) -> ObjectArray:
@@ -515,7 +514,7 @@ class TransformerConstant(Transformer[Any]):
 
     @override
     def legal_value(self, value: ObjectArray) -> Mask:
-        return value == self.value  # type: ignore
+        return np.array([v == self.value for v in value], dtype=np.bool_)
 
     @override
     def legal_vector(self, vector: Array[f64]) -> Mask:

--- a/src/ConfigSpace/hyperparameters/ordinal.py
+++ b/src/ConfigSpace/hyperparameters/ordinal.py
@@ -4,7 +4,7 @@ from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, ClassVar
-from typing_extensions import deprecated
+from typing_extensions import deprecated, override
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from ConfigSpace.hyperparameters.hp_components import (
     ordinal_neighborhood,
 )
 from ConfigSpace.hyperparameters.hyperparameter import Hyperparameter
-from ConfigSpace.types import Array, NotSet, _NotSet, i64
+from ConfigSpace.types import Array, Mask, NotSet, _NotSet, f64, i64
 
 
 @dataclass(init=False)
@@ -51,11 +51,13 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
     """Size of the hyperparameter, which is the number of possible values the
     hyperparameter can take on within the specified sequence."""
 
+    _contains_sequence_as_value: bool
+
     def __init__(
         self,
         name: str,
         sequence: Sequence[Any],
-        default_value: Any | None = None,
+        default_value: Any | _NotSet = NotSet,
         meta: Mapping[Hashable, Any] | None = None,
     ) -> None:
         """Initialize an ordinal hyperparameter.
@@ -80,7 +82,7 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
             )
 
         size = len(sequence)
-        if default_value is None:
+        if default_value is NotSet:
             default_value = sequence[0]
         elif default_value not in sequence:
             raise ValueError(
@@ -88,16 +90,31 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
                 f"Got {default_value!r} which is not in {sequence}.",
             )
 
-        seq_choices = np.asarray(sequence)
-        # NOTE: Unfortunatly, numpy will promote number types to str
-        # if there are string types in the array, where we'd rather
-        # stick to object type in that case. Hence the manual...
-        if seq_choices.dtype.kind in {"U", "S"} and not all(
-            isinstance(item, str) for item in sequence
-        ):
-            seq_choices = np.asarray(sequence, dtype=object)
+        try:
+            # This can fail with a ValueError if the choices contain arbitrary objects
+            # that are list like.
+            seq_choices = np.asarray(sequence)
+
+            # NOTE: Unfortunatly, numpy will promote number types to str
+            # if there are string types in the array, where we'd rather
+            # stick to object type in that case. Hence the manual...
+            if seq_choices.dtype.kind in {"U", "S"} and not all(
+                isinstance(item, str) for item in sequence
+            ):
+                seq_choices = np.array(sequence, dtype=object)
+
+        except ValueError:
+            seq_choices = list(sequence)
 
         self.sequence = tuple(sequence)
+
+        # If the Hyperparameter recieves as a Sequence during legality checks or
+        # conversions, we need to inform it that one of the values is a Sequence itself,
+        # i.e. we should treat it as a single value and not a list of multiple values
+        self._contains_sequence_as_value = any(
+            isinstance(item, Sequence) and not isinstance(item, str)
+            for item in self.sequence
+        )
 
         super().__init__(
             name=name,
@@ -154,6 +171,76 @@ class OrdinalHyperparameter(Hyperparameter[Any, Any]):
             f"Default: {self.default_value}",
         ]
         return ", ".join(parts)
+
+    @override
+    def to_vector(self, value: Any | Sequence[Any] | Array[Any]) -> f64 | Array[f64]:
+        if isinstance(value, np.ndarray):
+            return self._transformer.to_vector(value)
+
+        if isinstance(value, str):
+            return self._transformer.to_vector(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.to_vector(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.to_vector(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.to_vector(np.array([value]))[0]
+
+    @override
+    def legal_value(self, value: Any | Sequence[Any] | Array[Any]) -> bool | Mask:
+        if isinstance(value, np.ndarray):
+            return self._transformer.legal_value(value)
+
+        if isinstance(value, str):
+            return self._transformer.legal_value(np.array([value]))[0]
+
+        # Got a sequence of things, could be a list of stuff or a single value which is
+        # itself a list, e.g. a tuple (1, 2) indicating a single value
+        # If we could have single values which are sequences, we need to do some
+        # magic to get it into an array without numpy flattening it down
+        if isinstance(value, Sequence):
+            if self._contains_sequence_as_value:
+                # https://stackoverflow.com/a/47389566/5332072
+                _v = np.empty(1, dtype=object)
+                _v[0] = value
+                return self._transformer.legal_value(_v)[0]
+
+            # A sequence of things containing different values
+            return self._transformer.legal_value(np.asarray(value))
+
+        # Single value that is not a sequence
+        return self._transformer.legal_value(np.array([value]))[0]
+
+    @override
+    def pdf_values(self, values: Sequence[Any] | Array[Any]) -> Array[f64]:
+        if isinstance(values, np.ndarray):
+            if values.ndim != 1:
+                raise ValueError("Method pdf expects a one-dimensional numpy array")
+
+            vector = self.to_vector(values)
+            return self.pdf_vector(vector)
+
+        if self._contains_sequence_as_value:
+            # We have to convert it into a numpy array of objects carefully
+            # https://stackoverflow.com/a/47389566/5332072
+            _v = np.empty(len(values), dtype=object)
+            _v[:] = values
+            _vector: Array[f64] = self.to_vector(_v)  # type: ignore
+            return self.pdf_vector(_vector)
+
+        vector: Array[f64] = self.to_vector(values)  # type: ignore
+        return self.pdf_vector(vector)
 
     @property
     @deprecated("Please use 'len(hp.sequence)' or `hp.size` instead.")

--- a/src/ConfigSpace/util.py
+++ b/src/ConfigSpace/util.py
@@ -50,6 +50,7 @@ from ConfigSpace.hyperparameters import (
     UniformFloatHyperparameter,
     UniformIntegerHyperparameter,
 )
+from ConfigSpace.types import NotSet
 
 if TYPE_CHECKING:
     from ConfigSpace.configuration_space import ConfigurationSpace
@@ -82,8 +83,8 @@ def impute_inactive_values(
     """
     values = {}
     for hp in configuration.config_space.values():
-        value = configuration.get(hp.name)
-        if value is None:
+        value = configuration.get(hp.name, NotSet)
+        if value is NotSet:
             if strategy == "default":
                 new_value = hp.default_value
 


### PR DESCRIPTION
Supersedes #359 as the follow up to #346

Allows arbitrary values in the above hyperparameters. This by itself is not too difficult but supporting nested lists of objects became difficult to to numpy array functions which would treat it as a 2d array.

* Closes #86
* Closes #95
* Closes #370 

