### PR TITLE
Forbidden Relations of Disabled Hyperparameters

### DIFF
--- a/docs/scripts/api_generator.py
+++ b/docs/scripts/api_generator.py
@@ -2,6 +2,7 @@
 
 # https://mkdocstrings.github.io/recipes/
 """
+
 from __future__ import annotations
 
 import logging

--- a/docs/scripts/debug_which_page_is_being_rendered.py
+++ b/docs/scripts/debug_which_page_is_being_rendered.py
@@ -3,6 +3,7 @@ print the path to the file being rendered.
 
 This makes it easier to identify which file is being rendered when an error happens.
 """
+
 from __future__ import annotations
 
 import logging
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     import mkdocs.structure.pages
 
 log = logging.getLogger("mkdocs")
+
 
 def on_pre_page(
     page: mkdocs.structure.pages.Page,

--- a/src/ConfigSpace/forbidden.py
+++ b/src/ConfigSpace/forbidden.py
@@ -620,7 +620,10 @@ class ForbiddenLessThanRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        return self.left.to_value(left) < self.right.to_value(right)
+        mask = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(mask)
+        out[mask] = self.left.to_value(left[mask]) < self.right.to_value(right[mask])
+        return out
 
 
 class ForbiddenEqualsRelation(ForbiddenRelation):
@@ -686,7 +689,10 @@ class ForbiddenEqualsRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        return self.left.to_value(left) == self.right.to_value(right)  # type: ignore
+        mask = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(mask)
+        out[mask] = self.left.to_value(left[mask]) == self.right.to_value(right[mask])
+        return out  # type: ignore
 
 
 class ForbiddenGreaterThanRelation(ForbiddenRelation):
@@ -751,7 +757,10 @@ class ForbiddenGreaterThanRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        return self.left.to_value(left) > self.right.to_value(right)
+        mask = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(mask)
+        out[mask] = self.left.to_value(left[mask]) > self.right.to_value(right[mask])
+        return out
 
 
 ForbiddenLike = Union[

--- a/src/ConfigSpace/forbidden.py
+++ b/src/ConfigSpace/forbidden.py
@@ -622,9 +622,9 @@ class ForbiddenLessThanRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        mask = ~(np.isnan(left) | np.isnan(right))
-        out = np.zeros_like(mask)
-        out[mask] = self.left.to_value(left[mask]) < self.right.to_value(right[mask])
+        valid = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(valid)
+        out[valid] = self.left.to_value(left[valid]) < self.right.to_value(right[valid])
         return out
 
 
@@ -693,9 +693,9 @@ class ForbiddenEqualsRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        mask = ~(np.isnan(left) | np.isnan(right))
-        out = np.zeros_like(mask)
-        out[mask] = self.left.to_value(left[mask]) == self.right.to_value(right[mask])
+        valid = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(valid)
+        out[valid] = self.left.to_value(left[valid]) == self.right.to_value(right[valid])
         return out  # type: ignore
 
 
@@ -763,9 +763,9 @@ class ForbiddenGreaterThanRelation(ForbiddenRelation):
     def is_forbidden_vector_array(self, arr: Array[f64]) -> Mask:
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
-        mask = ~(np.isnan(left) | np.isnan(right))
-        out = np.zeros_like(mask)
-        out[mask] = self.left.to_value(left[mask]) > self.right.to_value(right[mask])
+        valid = ~(np.isnan(left) | np.isnan(right))
+        out = np.zeros_like(valid)
+        out[valid] = self.left.to_value(left[valid]) > self.right.to_value(right[valid])
         return out
 
 

--- a/src/ConfigSpace/forbidden.py
+++ b/src/ConfigSpace/forbidden.py
@@ -694,8 +694,9 @@ class ForbiddenEqualsRelation(ForbiddenRelation):
         left = arr[self.vector_ids[0]]
         right = arr[self.vector_ids[1]]
         valid = ~(np.isnan(left) | np.isnan(right))
+        tmp = self.left.to_value(left[valid]) == self.right.to_value(right[valid])
         out = np.zeros_like(valid)
-        out[valid] = self.left.to_value(left[valid]) == self.right.to_value(right[valid])
+        out[valid] = tmp
         return out  # type: ignore
 
 

--- a/src/ConfigSpace/forbidden.py
+++ b/src/ConfigSpace/forbidden.py
@@ -614,6 +614,8 @@ class ForbiddenLessThanRelation(ForbiddenRelation):
         # Relation is always evaluated against actual value and not vector rep
         left: f64 = vector[self.vector_ids[0]]  # type: ignore
         right: f64 = vector[self.vector_ids[1]]  # type: ignore
+        if np.isnan(left) or np.isnan(right):
+            return False
         return self.left.to_value(left) < self.right.to_value(right)  # type: ignore
 
     @override
@@ -683,6 +685,8 @@ class ForbiddenEqualsRelation(ForbiddenRelation):
         # Relation is always evaluated against actual value and not vector rep
         left = vector[self.vector_ids[0]]
         right = vector[self.vector_ids[1]]
+        if np.isnan(left) or np.isnan(right):
+            return False
         return self.left.to_value(left) == self.right.to_value(right)  # type: ignore
 
     @override
@@ -751,6 +755,8 @@ class ForbiddenGreaterThanRelation(ForbiddenRelation):
         # Relation is always evaluated against actual value and not vector rep
         left: f64 = vector[self.vector_ids[0]]  # type: ignore
         right: f64 = vector[self.vector_ids[1]]  # type: ignore
+        if np.isnan(left) or np.isnan(right):
+            return False
         return self.left.to_value(left) > self.right.to_value(right)  # type: ignore
 
     @override

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -301,8 +301,9 @@ def test_relation_conditioned():
     cond_a = EqualsCondition(a, enable_a, True)
 
     b = OrdinalHyperparameter('b', [5, 10, 15])
-    forbid_a_b = ForbiddenEqualsRelation(a, b)
+    for forbid in ForbiddenEqualsRelation, ForbiddenGreaterThanRelation, ForbiddenLessThanRelation:
+        forbid_a_b = forbid(a, b)
 
-    cs = ConfigurationSpace()
-    cs.add([a, enable_a, cond_a, b, forbid_a_b])
-    cs.sample_configuration(100)
+        cs = ConfigurationSpace()
+        cs.add([a, enable_a, cond_a, b, forbid_a_b])
+        cs.sample_configuration(100)

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -296,12 +296,16 @@ def test_relation():
 def test_relation_conditioned():
     from ConfigSpace import EqualsCondition, ConfigurationSpace
 
-    a = OrdinalHyperparameter('a', [2, 5, 10])
-    enable_a = CategoricalHyperparameter('enable_a', [False, True], weights=[99999, 1])
+    a = OrdinalHyperparameter("a", [2, 5, 10])
+    enable_a = CategoricalHyperparameter("enable_a", [False, True], weights=[99999, 1])
     cond_a = EqualsCondition(a, enable_a, True)
 
-    b = OrdinalHyperparameter('b', [5, 10, 15])
-    for forbid in ForbiddenEqualsRelation, ForbiddenGreaterThanRelation, ForbiddenLessThanRelation:
+    b = OrdinalHyperparameter("b", [5, 10, 15])
+    for forbid in (
+        ForbiddenEqualsRelation,
+        ForbiddenGreaterThanRelation,
+        ForbiddenLessThanRelation,
+    ):
         forbid_a_b = forbid(a, b)
 
         cs = ConfigurationSpace()

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -291,3 +291,18 @@ def test_relation():
     assert forb.is_forbidden_value(
         {"water_temperature": "hot", "water_temperature2": "cold"},
     )
+
+
+def test_relation_conditioned():
+    from ConfigSpace import EqualsCondition, ConfigurationSpace
+    a = OrdinalHyperparameter('a', [2, 5, 10])
+    enable_a = CategoricalHyperparameter('enable_a', [False, True])
+    cond_a = EqualsCondition(a, enable_a, True)
+
+    b = OrdinalHyperparameter('b', [5, 10, 15])
+    forbid_a_b = ForbiddenEqualsRelation(a, b)
+    # forbid_a = ForbiddenEqualsClause(enable_a, True)
+    # forbid_a_b = ForbiddenAndConjunction(forbid_a, forbid_a_b)
+
+    cs = ConfigurationSpace()
+    cs.add([a, enable_a, cond_a, b, forbid_a_b])

--- a/test/test_forbidden.py
+++ b/test/test_forbidden.py
@@ -295,14 +295,14 @@ def test_relation():
 
 def test_relation_conditioned():
     from ConfigSpace import EqualsCondition, ConfigurationSpace
+
     a = OrdinalHyperparameter('a', [2, 5, 10])
-    enable_a = CategoricalHyperparameter('enable_a', [False, True])
+    enable_a = CategoricalHyperparameter('enable_a', [False, True], weights=[99999, 1])
     cond_a = EqualsCondition(a, enable_a, True)
 
     b = OrdinalHyperparameter('b', [5, 10, 15])
     forbid_a_b = ForbiddenEqualsRelation(a, b)
-    # forbid_a = ForbiddenEqualsClause(enable_a, True)
-    # forbid_a_b = ForbiddenAndConjunction(forbid_a, forbid_a_b)
 
     cs = ConfigurationSpace()
     cs.add([a, enable_a, cond_a, b, forbid_a_b])
+    cs.sample_configuration(100)


### PR DESCRIPTION
Avoid evaluating forbidden relations on HPs that were disabled/not sampled because of other conditions that were not met, since retrieving `int` values (for category indices) from `nan`s fails.

Fixes https://github.com/automl/ConfigSpace/issues/396 (also see https://github.com/automl/SMAC3/issues/1161).