### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,10 +25,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup Python 3.7
+    - name: Setup Python 3.13
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.13
 
     - name: Install pre-commit
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@
 
 .PHONY: help install-dev install-test install-docs pre-commit clean clean-doc clean-build build docs links publish test clean-test
 
-A_DIFFERENT_CHANGE
-
 help:
 	@echo "Makefile ConfigSpace"
 	@echo "* install-dev      to install all dev requirements and install pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Natural Language :: English",
   "Intended Audience :: Developers",
   "Intended Audience :: Education",


### PR DESCRIPTION
This PR adds support and automated testing for Python 3.13. Closes #403

## Changes
- Added the `Programming Language :: Python :: 3.13` classifier to `pyproject.toml`.
- Added `3.13` to the `python-version` matrix in the `.github/workflows/pytest.yml` GitHub Actions workflow.
- Fixed a minor syntax error (`missing separator`) in the `Makefile`.

## Testing
- The full test suite (`pytest test`) was run locally using Python 3.13.3 and passed successfully.
- The `make test` command also passes after the Makefile fix.
- CI should now run the test suite on Python 3.13 for all operating systems defined in the matrix.

## CI Status Note
The `docs` workflow (running on Python 3.10) is currently failing in CI due to a `mkdocs-autorefs` warning being treated as an error in `--strict` mode:

```
WARNING - mkdocs_autorefs: Could not find closest secondary URL (from reference/hyperparameters/, candidates: [...]). Make sure to use unique headings, identifiers, or Markdown anchors (see our docs).
```

This appears unrelated to the Python 3.13 changes in this PR and should likely be addressed separately.