### PR TITLE
fix: shuffle to undo unique sort

### DIFF
--- a/src/ConfigSpace/hyperparameters/distributions.py
+++ b/src/ConfigSpace/hyperparameters/distributions.py
@@ -181,6 +181,11 @@ def quantized_neighborhood(
         uniq = np.unique(candidates_quantized)
         new_uniq = np.setdiff1d(uniq, neighbors[:offset], assume_unique=True)
 
+        # Unfortunately, uniq sorts the values, so we lose the "centered"'ness, and
+        # `uniq` and `new_uniq` are now left-biased samples. We thus need to undo this
+        # sort operation.
+        seed.shuffle(new_uniq)
+
         n_new_unique = len(new_uniq)
         neighbors[offset : offset + n_new_unique] = new_uniq
         offset += n_new_unique
@@ -703,6 +708,10 @@ class DiscretizedContinuousScipyDistribution(Distribution, Generic[DType]):
             uniq = np.unique(candidates_quantized)
             new_uniq = np.setdiff1d(uniq, neighbors[:offset], assume_unique=True)
 
+            # Unfortunately, uniq sorts the values, so we lose the "centered"'ness'
+            # Shuffle the new_uniq to ensure we have a random distribution
+            seed.shuffle(new_uniq)
+
             n_new_unique = len(new_uniq)
             neighbors[offset : offset + n_new_unique] = new_uniq
             offset += n_new_unique
@@ -1077,6 +1086,10 @@ class UniformIntegerDistribution(Distribution):
 
             uniq = np.unique(candidates_quantized)
             new_uniq = np.setdiff1d(uniq, neighbors[:offset], assume_unique=True)
+
+            # Unfortunately, uniq sorts the values, so we lose the "centered"'ness'
+            # Shuffle the new_uniq to ensure we have a random distribution
+            seed.shuffle(new_uniq)
 
             n_new_unique = len(new_uniq)
             neighbors[offset : offset + n_new_unique] = new_uniq

--- a/test/test_hyperparameters.py
+++ b/test/test_hyperparameters.py
@@ -1471,11 +1471,11 @@ def test_normalint():
     f1 = NormalIntegerHyperparameter("param", 0, 10, lower=-100, upper=100)
     np.testing.assert_equal(
         f1.neighbors_vectorized(0.1, seed=np.random.RandomState(9001), n=1),
-        np.array([0.14]),
+        np.array([0.415]),
     )
     np.testing.assert_equal(
         f1.neighbors_vectorized(0.1, seed=np.random.RandomState(9001), n=5),
-        np.array([0.06, 0.065, 0.09, 0.14, 0.175]),
+        np.array([0.175, 0.065, 0.265, 0.06, 0.14]),
     )
 
     # Bounded case with default value out of bounds

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -164,16 +164,16 @@ def test_random_neighborhood_int():
     hp = UniformIntegerHyperparameter("a", 1, 10)
     all_neighbors = _test_get_one_exchange_neighbourhood(hp)
     all_neighbors = [neighbor["a"] for neighbor in all_neighbors]
-    assert pytest.approx(np.mean(all_neighbors), abs=1e-2) == 4.64
-    assert pytest.approx(np.var(all_neighbors), abs=1e-2) == 3.57
+    assert pytest.approx(np.mean(all_neighbors), abs=1e-2) == 5.8825
+    assert pytest.approx(np.var(all_neighbors), abs=1e-2) == 5.93
 
     hp = UniformIntegerHyperparameter("a", 1, 10, log=True)
     all_neighbors = _test_get_one_exchange_neighbourhood(hp)
     all_neighbors = [neighbor["a"] for neighbor in all_neighbors]
     assert hp.default_value == 3
 
-    assert pytest.approx(np.mean(all_neighbors), abs=1e-2) == 3.155
-    assert pytest.approx(np.var(all_neighbors), abs=1e-2) == 3.09
+    assert pytest.approx(np.mean(all_neighbors), abs=1e-2) == 3.98
+    assert pytest.approx(np.var(all_neighbors), abs=1e-2) == 5.499
 
 
 def test_random_neighbor_cat():


### PR DESCRIPTION
* Closes #405 


@LukasFehring Anyone going to take over on `ConfigSpace` from Hannover side? I'm not supported to really maintain `ConfigSpace` as I've left AutoML.org